### PR TITLE
fix(overflow): respect maxRows when visible items wrap (#17)

### DIFF
--- a/demo/src/stories/Issue17TruncatableSibling.stories.tsx
+++ b/demo/src/stories/Issue17TruncatableSibling.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { OverflowList } from "react-responsive-overflow-list";
+
+/**
+ * Repro for https://github.com/Eliav2/react-responsive-overflow-list/issues/17
+ *
+ * The OverflowList shares a flex row with a sibling whose width is elastic
+ * (a truncatable `<span style={{ minWidth: 0 }}>`). Because the OverflowList's
+ * own width is content-driven (flex-basis: auto), the width it is *measured* at
+ * (all items rendered, sibling shrunk) differs from the width it is finally
+ * *rendered* at (fewer items, sibling expanded). At certain container widths the
+ * visible item + overflow indicator no longer fit on one line and wrap to a 2nd
+ * row, violating `maxRows={1}`.
+ *
+ * Resize the red box slowly to reproduce — it happens at specific widths (~180-230px).
+ */
+const Issue17Repro = ({ maxRows = 1 }: { maxRows?: number }) => {
+  // Bumping this key remounts the OverflowList, forcing a fresh measuring pass
+  // (same effect as a page reload). Use it to check whether a stuck/collapsed
+  // state re-resolves once re-measured at the current container width.
+  const [renderKey, setRenderKey] = useState(0);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "flex-start" }}>
+      <button onClick={() => setRenderKey((k) => k + 1)} style={{ padding: "4px 10px" }}>
+        Force re-render (remount) — count: {renderKey}
+      </button>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          border: "2px solid red",
+          padding: 8,
+          resize: "horizontal",
+          overflow: "auto",
+          width: 250,
+          maxWidth: "100%",
+        }}
+      >
+        <span
+          style={{
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            minWidth: 0,
+            background: "#cef",
+          }}
+        >
+          I could be truncated
+        </span>
+        <OverflowList
+          key={renderKey}
+          items={["foo", "bar", "baz"]}
+          renderItem={(item) => <span style={{ padding: 4, background: "#fec" }}>{item}</span>}
+          renderOverflow={(items) => <span style={{ padding: 4, background: "#fcc" }}>{items.length}</span>}
+          style={{ gap: 8, border: "1px dashed blue" }}
+          maxRows={maxRows}
+        />
+      </div>
+    </div>
+  );
+};
+
+const meta = {
+  title: "Issues/Issue17 - Truncatable Sibling Wrapping",
+  component: Issue17Repro,
+} satisfies Meta<typeof Issue17Repro>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Items wrap onto 2 rows despite `maxRows={1}` at narrow container widths.
+ * Drag the bottom-right resize handle of the red box to find the broken widths.
+ */
+export const WrapsDespiteMaxRows1: Story = {
+  args: { maxRows: 1 },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-overflow-list",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "description": "A responsive React component that shows as many items as can fit within constraints, hiding overflow items behind a configurable overflow renderer",
   "module": "dist/index.js",

--- a/src/hooks/useOverflowList.ts
+++ b/src/hooks/useOverflowList.ts
@@ -126,8 +126,15 @@ export function useOverflowList<
     const lastRowTop = rowPositions[rowPositions.length - 1];
     const lastRow = itemsSizesMap[lastRowTop];
 
-    // if the overflow indicator item opens a new row(we check it by the middle of the item)
-    if (overflowMiddleY > lastRow.bottom) {
+    // The visible items themselves may occupy more than maxRows once the container
+    // settles at its final (narrower) width — countVisibleItems measured them while
+    // all items were rendered (a wider container if it is a content-sized flex item).
+    const itemRowCount = rowPositions.length;
+
+    // Subtract if either the visible items overflow maxRows, or the overflow
+    // indicator opens a new row below the last item row.
+    const indicatorOpensNewRow = overflowMiddleY > lastRow.bottom;
+    if (itemRowCount > maxRows || indicatorOpensNewRow) {
       setSubtractCount((c) => c + 1);
       return true;
     }


### PR DESCRIPTION
Fixes #17 (the `maxRows` violation — items wrapping to extra rows).

## Root cause
When `OverflowList` is a **content-sized flex item** sharing a row with a shrinkable sibling (the repro: a `min-width:0` truncatable `<span>`), its width depends on how many children it renders:

- `measuring` phase renders **all** items → container is **wide** (sibling shrinks).
- `normal` phase renders the subset + indicator → container is **narrow** (sibling expands back).

`countVisibleItems` measures at the wide width and picks `visibleCount` accordingly. `updateOverflowIndicator` then only checked whether the **indicator** opened a new row below the items — it never re-checked whether the **visible items themselves** still fit within `maxRows` at the settled narrower width. So it stopped subtracting too early and the items wrapped past `maxRows`.

Real trace at container width 200px (before fix):
```
count:  cw=77  rowSizes=[2,1]  fittingCount=2   ← measured wide (all items)
updInd: cw=69  midY=131 < lastBottom=147  sub=FALSE
normal: foo,bar,1 → rows=2                       ← wrapped, maxRows=1 violated
```

## Fix
Also subtract while the visible items span more than `maxRows` rows (`rowPositions.length > maxRows`), not only when the indicator spills.

```ts
const itemRowCount = rowPositions.length;
const indicatorOpensNewRow = overflowMiddleY > lastRow.bottom;
if (itemRowCount > maxRows || indicatorOpensNewRow) {
  setSubtractCount((c) => c + 1);
  return true;
}
```

No behavior change for stable-width containers: there the measuring and normal widths are equal, so `itemRowCount` never exceeds `maxRows` and the new condition is never hit.

## Testing (real ResizeObserver, browser)
- Repro sweep 400→120px: **every width now rows=1** (was rows=2 at ≤230px). Zero `maxRows` violations.
- **No render loop**: render count stable (15→15) over 1s at the broken width.
- **No regression**: examples page — single-row examples stay 1 row, multi-row examples unchanged.
- `pnpm build` + `pnpm type-check` pass.

## Scope / known limitation
- This fixes the **wrap-past-maxRows** bug (issue #17, first screenshot).
- The **"stays collapsed after expanding"** behavior (second screenshot) is **not** addressed here. That is a stale-state issue: when the container grows, a collapsed content-sized `OverflowList`'s own box doesn't change, so its `ResizeObserver` doesn't fire. Watching the parent from inside the child breaks composition, so re-triggering a remeasure on grow is left to the consumer (e.g. bump a `key`). A Storybook repro with a remount button is included to illustrate this.
- At the 230–260px boundary the fix may collapse to the indicator only (`"3"`) where one item could still fit — strictly safe (never violates `maxRows`), slightly conservative. Rooted in the same content-sized-width circularity.

## Added
- `demo/src/stories/Issue17TruncatableSibling.stories.tsx` — repro story (`Issues/Issue17`) with resizable container + force-remount button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)