### PR TITLE
fix: keep react-dom a single instance in demo builds

### DIFF
--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
     alias: {
       "@": path.resolve(__dirname, "./src"),
     },
+    // Guard against bundling two react-dom copies (workspace lib resolves its
+    // auto-installed peer independently of the demo; a version split makes
+    // flushSync from the lib a silent no-op in production builds).
+    dedupe: ["react", "react-dom"],
   },
   plugins: [
     tsConfigPaths({

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "react": "catalog:",
+    "react-dom": "catalog:",
     "shadcn": "^3.7.0",
     "tsdown": "^0.2.0",
     "typescript": "^5.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,6 @@ catalogs:
 importers:
 
   .:
-    dependencies:
-      react-dom:
-        specifier: '>=16.8.0'
-        version: 19.1.1(react@19.1.1)
     devDependencies:
       '@base-ui/react':
         specifier: ^1.1.0
@@ -42,6 +38,9 @@ importers:
       react:
         specifier: 'catalog:'
         version: 19.1.1
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.1.1(react@19.1.1)
       shadcn:
         specifier: ^3.7.0
         version: 3.7.0(@types/node@24.5.2)(hono@4.11.7)(typescript@5.8.3)


### PR DESCRIPTION
## What Problem This Solves

The flicker investigated in facebook/react#35151 turned out to be two react-dom copies in the demo's production bundle, not a React regression. The workspace root's react-dom peer is auto-installed by pnpm against the floating `>=16.8.0` range and recorded in the lockfile independently of the demo's catalog pin. When the catalog is bumped (as on the `react-19.2` demo branch), the two resolutions split, Vite bundles both copies, and the lib's `flushSync` binds to a react-dom instance that owns no roots: a silent no-op. The resize re-measurement then renders one frame late and the list flickers, in production builds only (the dev server's dep optimizer collapses bare imports to one copy, which is why dev never showed it).

## The Fix

- Pin `react-dom` as an explicit `catalog:` devDependency at the workspace root, so the lib and the demo always resolve the same version and the lockfile can no longer drift on a catalog bump.
- Add `resolve.dedupe: ["react", "react-dom"]` to the demo Vite config as a structural guard: even if a resolution split reappears, only one copy gets bundled.

## Evidence

- `react-19.2` branch lockfile: root importer `react-dom: 19.1.1(react@19.2.0)` vs demo `19.2.0(react@19.2.0)` (the split); `react-19.1` branch resolves both to `19.1.1(react@19.1.1)` (no split, no flicker).
- Side-by-side repro with the app's react-dom and the lib's flushSync react-dom pinned independently: single instance at 19.2.0 settles the DOM before flushSync returns; split instances reproduce the painted intermediate frame with no CPU throttling. Full write-up in facebook/react#35151.
- `pnpm install --lockfile-only` accepts the updated lockfile unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)