### PR TITLE
fix(overflow): re-measure when items change size on their own (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 # Changelog
 
+## 0.4.3
+
+- Fixed a stale visible count when items change size on their own (#21). Measurement was only re-triggered by
+  `itemCount`/`maxRows` changing or by the container's own ResizeObserver, so items that grow or shrink while the
+  container's box stays put — a counter badge going from `9` to `10` in a tab bar — never caused a new pass. Usually the
+  resulting wrap makes the container taller and its ResizeObserver rescues it, which is why this looked intermittent and
+  browser-specific; when the container has a fixed height nothing re-triggers a pass and the overflow indicator sits on a
+  second row indefinitely, violating `maxRows`. The settled content footprint is now compared after each commit, so both
+  directions are caught: items growing past the row, and items shrinking so more of them would fit again.
+
 ## 0.4.2
 
 - Fixed the list collapsing to a bare overflow indicator when the container held children that are not items. Row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   container's box stays put — a counter badge going from `9` to `10` in a tab bar — never caused a new pass. Usually the
   resulting wrap makes the container taller and its ResizeObserver rescues it, which is why this looked intermittent and
   browser-specific; when the container has a fixed height nothing re-triggers a pass and the overflow indicator sits on a
-  second row indefinitely, violating `maxRows`. The settled content footprint is now compared after each commit, so both
+  second row indefinitely, violating `maxRows`. The settled content signature is now compared after each commit, so both
   directions are caught: items growing past the row, and items shrinking so more of them would fit again.
 
 ## 0.4.2

--- a/demo/src/stories/Issue21DynamicItemWidths.stories.tsx
+++ b/demo/src/stories/Issue21DynamicItemWidths.stories.tsx
@@ -1,0 +1,217 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, useRef, useState } from "react";
+import { OverflowList } from "react-responsive-overflow-list";
+
+/**
+ * Repro for https://github.com/Eliav2/react-responsive-overflow-list/issues/21
+ *
+ * Filter tabs with counter badges. The badges grow as data arrives, so the *items* get wider while no
+ * item is added or removed. Measurement is only re-triggered by `[itemCount, maxRows]` or by the
+ * container's own ResizeObserver, and neither fires: `itemCount` is constant and the container's width is
+ * set from outside. `visibleCount` therefore stays at whatever fit before the badges grew, and the wider
+ * items plus the overflow indicator no longer fit on one line.
+ *
+ * The catch — and why this is hard to see — is that the component usually *rescues itself*: when the
+ * items wrap, the container gets taller, `useResizeObserver` reports the height change, and a fresh
+ * measuring pass runs. The bug only becomes visible when the container's box **cannot** change, which is
+ * the normal shape of a tab bar: a fixed height. Then nothing ever re-triggers measurement and the
+ * indicator sits on row 2 indefinitely.
+ *
+ * So the reported Firefox/Chromium split is not really about the engine. It is about whether the
+ * container's box is free to change in the layout it happens to sit in.
+ *
+ * `Remount` forces a fresh measuring pass at the current widths. It fixes the layout, which is the whole
+ * point: the measurement logic is right, the state is just stale.
+ */
+const TABS = ["Overview", "Assets", "Issues", "Policies", "Reports"];
+
+/** The width jumps called out in the issue: badge appears, 1 digit -> 2, then 2 digits -> "99+". */
+const STAGES = [
+  { label: "no badge", count: 0 },
+  { label: "badge appears (1)", count: 1 },
+  { label: "1 digit (9)", count: 9 },
+  { label: "2 digits (10)", count: 10 },
+  { label: "2 digits (99)", count: 99 },
+  { label: '"99+" (100)', count: 100 },
+];
+
+const TAB_BAR_HEIGHT = 34;
+
+const tabStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6,
+  padding: "4px 10px",
+  border: "1px solid #bbb",
+  borderRadius: 6,
+  background: "#f6f6f6",
+  whiteSpace: "nowrap",
+};
+
+const badgeStyle: React.CSSProperties = {
+  padding: "0 5px",
+  borderRadius: 8,
+  background: "#333",
+  color: "#fff",
+  fontSize: 11,
+  lineHeight: "16px",
+};
+
+const Tab = ({ name, count }: { name: string; count: number }) => (
+  <span style={tabStyle}>
+    {name}
+    {count > 0 && <span style={badgeStyle}>{count > 99 ? "99+" : count}</span>}
+  </span>
+);
+
+interface Issue21Props {
+  maxRows?: number;
+  containerWidth?: number;
+  /** Pin the list's height, as a real tab bar does, so wrapping cannot change its box. */
+  fixedHeight?: boolean;
+}
+
+const Issue21Repro = ({ maxRows = 1, containerWidth = 340, fixedHeight = true }: Issue21Props) => {
+  const [stage, setStage] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [remountKey, setRemountKey] = useState(0);
+
+  // Auto-advance, to mimic counters ticking up as data arrives.
+  useEffect(() => {
+    if (!playing) return;
+    const id = setInterval(() => {
+      setStage((s) => {
+        if (s >= STAGES.length - 1) {
+          setPlaying(false);
+          return s;
+        }
+        return s + 1;
+      });
+    }, 1200);
+    return () => clearInterval(id);
+  }, [playing]);
+
+  // Diagnostic only: count the rows the list's visible children actually occupy. Reads layout, never
+  // writes to it, so it cannot influence what the component measures.
+  //
+  // Deliberately a passive effect, not a layout effect: OverflowList's own layout effects run first (child
+  // before parent) and set the next phase, so a layout effect here would read the DOM of the phase that is
+  // about to be replaced and report a stale row count. A passive effect runs after paint, on the layout
+  // that is actually on screen.
+  const containerRef = useRef<HTMLElement | null>(null);
+  const [rows, setRows] = useState(1);
+  // No dep array on purpose: re-read after every render, including the ones the measuring phases cause.
+  // `setRows` bails when the value is unchanged, so this settles instead of looping.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const frame = requestAnimationFrame(() => {
+      const tops = new Set(
+        Array.from(el.children)
+          .filter((child) => child.getClientRects().length > 0)
+          .map((child) => Math.round(child.getBoundingClientRect().top)),
+      );
+      setRows((prev) => (prev === tops.size ? prev : tops.size));
+    });
+    return () => cancelAnimationFrame(frame);
+  });
+
+  const { count } = STAGES[stage];
+  const violated = rows > maxRows;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 12, alignItems: "flex-start" }}>
+      <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+        <button onClick={() => setStage((s) => Math.max(0, s - 1))} disabled={stage === 0}>
+          ◀ Prev
+        </button>
+        <button
+          onClick={() => setStage((s) => Math.min(STAGES.length - 1, s + 1))}
+          disabled={stage === STAGES.length - 1}
+        >
+          Next ▶
+        </button>
+        <button onClick={() => setPlaying((p) => !p)}>{playing ? "Pause" : "Play"}</button>
+        <button
+          onClick={() => {
+            setStage(0);
+            setPlaying(false);
+          }}
+        >
+          Reset
+        </button>
+        <button onClick={() => setRemountKey((k) => k + 1)}>Remount ({remountKey})</button>
+      </div>
+
+      <div style={{ fontSize: 13 }}>
+        stage {stage + 1}/{STAGES.length}: <strong>{STAGES[stage].label}</strong> &nbsp;|&nbsp; measured rows:{" "}
+        <strong style={{ color: violated ? "#c00" : "#070" }}>{rows}</strong> (maxRows={maxRows}){" "}
+        {violated && <strong style={{ color: "#c00" }}>← maxRows violated</strong>}
+      </div>
+
+      {/* The width is set from outside, so growing items never change the list's width. With
+          fixedHeight, wrapping cannot change its height either, so its ResizeObserver never fires. */}
+      <div
+        style={{
+          width: containerWidth,
+          resize: "horizontal",
+          overflow: "auto",
+          border: "2px solid red",
+          padding: 8,
+        }}
+      >
+        <OverflowList
+          key={remountKey}
+          ref={containerRef}
+          items={TABS}
+          maxRows={maxRows}
+          renderItem={(name) => <Tab name={name} count={count} />}
+          renderOverflow={(hidden) => (
+            <span style={{ ...tabStyle, background: "#ffecec", borderColor: "#e0a0a0" }}>More ({hidden.length})</span>
+          )}
+          style={
+            fixedHeight
+              ? { gap: 8, height: TAB_BAR_HEIGHT * maxRows, alignContent: "flex-start" }
+              : { gap: 8 }
+          }
+        />
+      </div>
+
+      <span style={{ fontSize: 12, color: "#666", maxWidth: 620 }}>
+        Neither the item count nor the list's box changes, so nothing re-triggers measurement. Drag the red
+        box to park it near a fit boundary, then step the stages.
+      </span>
+    </div>
+  );
+};
+
+const meta = {
+  title: "Issues/Issue21 - Dynamic Item Widths",
+  component: Issue21Repro,
+} satisfies Meta<typeof Issue21Repro>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * The bug. Fixed-height tab bar, `maxRows={1}`. Step from "no badge" to "99+" and the indicator drops to
+ * row 2 and stays there. Reproduces at every width from 300px to 540px. `Remount` clears it.
+ */
+export const FixedHeightIndicatorWraps: Story = {
+  args: { maxRows: 1, containerWidth: 340, fixedHeight: true },
+};
+
+/**
+ * Control: same growth, height left elastic. Wrapping makes the list taller, its ResizeObserver fires, a
+ * new measuring pass runs, and the row count snaps back to 1. This is why the bug looks intermittent and
+ * engine-specific in the wild.
+ */
+export const ElasticHeightSelfHeals: Story = {
+  args: { maxRows: 1, containerWidth: 340, fixedHeight: false },
+};
+
+/** The same staleness with two rows allowed, to show the violation is about `maxRows`, not about "1". */
+export const FixedHeightMaxRows2: Story = {
+  args: { maxRows: 2, containerWidth: 260, fixedHeight: true },
+};

--- a/demo/src/stories/Issue21DynamicItemWidths.stories.tsx
+++ b/demo/src/stories/Issue21DynamicItemWidths.stories.tsx
@@ -3,25 +3,30 @@ import { useEffect, useRef, useState } from "react";
 import { OverflowList } from "react-responsive-overflow-list";
 
 /**
- * Repro for https://github.com/Eliav2/react-responsive-overflow-list/issues/21
+ * Regression cover for https://github.com/Eliav2/react-responsive-overflow-list/issues/21
  *
- * Filter tabs with counter badges. The badges grow as data arrives, so the *items* get wider while no
- * item is added or removed. Measurement is only re-triggered by `[itemCount, maxRows]` or by the
- * container's own ResizeObserver, and neither fires: `itemCount` is constant and the container's width is
- * set from outside. `visibleCount` therefore stays at whatever fit before the badges grew, and the wider
- * items plus the overflow indicator no longer fit on one line.
+ * Every list here must stay within its `maxRows` through the whole badge-growth sequence, in both
+ * directions. Story names describe the bug each one reproduced, matching `WrapsDespiteMaxRows1` (#17) and
+ * `CollapsesToBareIndicator` (#23).
  *
- * The catch — and why this is hard to see — is that the component usually *rescues itself*: when the
- * items wrap, the container gets taller, `useResizeObserver` reports the height change, and a fresh
- * measuring pass runs. The bug only becomes visible when the container's box **cannot** change, which is
- * the normal shape of a tab bar: a fixed height. Then nothing ever re-triggers measurement and the
- * indicator sits on row 2 indefinitely.
+ * Filter tabs with counter badges. The badges grow as data arrives, so the *items* get wider while no item
+ * is added or removed. Measurement used to be re-triggered only by `[itemCount, maxRows]` or by the
+ * container's own ResizeObserver, and neither fires here: `itemCount` is constant and the container's width
+ * is set from outside. `visibleCount` therefore stayed at whatever fit before the badges grew, and the
+ * wider items plus the overflow indicator no longer fit on one line.
  *
- * So the reported Firefox/Chromium split is not really about the engine. It is about whether the
+ * What made it hard to see is that the component usually *rescued itself*: when the items wrap, the
+ * container gets taller, `useResizeObserver` reports the height change, and a fresh measuring pass runs. It
+ * only stayed broken when the container's box **could not** change, the normal shape of a tab bar: a fixed
+ * height. Then nothing re-triggered measurement and the indicator sat on row 2 indefinitely.
+ *
+ * So the reported Firefox/Chromium split was not really about the engine. It was about whether the
  * container's box is free to change in the layout it happens to sit in.
  *
- * `Remount` forces a fresh measuring pass at the current widths. It fixes the layout, which is the whole
- * point: the measurement logic is right, the state is just stale.
+ * The fix compares the settled content signature after every commit, so a size change re-triggers a pass
+ * on its own. `Remount` remains useful as a control: it forces a fresh pass at the current widths, and it
+ * produced the same result as the fix does, which is what showed the measurement logic was right all along
+ * and only the state was stale.
  */
 const TABS = ["Overview", "Assets", "Issues", "Policies", "Reports"];
 
@@ -149,8 +154,9 @@ const Issue21Repro = ({ maxRows = 1, containerWidth = 340, fixedHeight = true }:
         {violated && <strong style={{ color: "#c00" }}>← maxRows violated</strong>}
       </div>
 
-      {/* The width is set from outside, so growing items never change the list's width. With
-          fixedHeight, wrapping cannot change its height either, so its ResizeObserver never fires. */}
+      {/* The width is set from outside, so growing items never change the list's width. With fixedHeight,
+          wrapping cannot change its height either, so its ResizeObserver never fires and the content
+          signature is the only thing left to notice the change. */}
       <div
         style={{
           width: containerWidth,
@@ -178,8 +184,9 @@ const Issue21Repro = ({ maxRows = 1, containerWidth = 340, fixedHeight = true }:
       </div>
 
       <span style={{ fontSize: 12, color: "#666", maxWidth: 620 }}>
-        Neither the item count nor the list's box changes, so nothing re-triggers measurement. Drag the red
-        box to park it near a fit boundary, then step the stages.
+        Neither the item count nor the list's box changes here, so the only signal left is that the items
+        themselves changed size. Drag the red box to park it near a fit boundary, then step the stages: the
+        row count must stay within maxRows the whole way up and back down.
       </span>
     </div>
   );
@@ -195,23 +202,29 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 /**
- * The bug. Fixed-height tab bar, `maxRows={1}`. Step from "no badge" to "99+" and the indicator drops to
- * row 2 and stays there. Reproduces at every width from 300px to 540px. `Remount` clears it.
+ * The case that was broken. Fixed-height tab bar, `maxRows={1}`.
+ *
+ * Expected: one row at every stage, items moving into `More (N)` as the badges grow and back out as they
+ * shrink. Before the fix the indicator dropped to row 2 at the first badge and stayed there, at every width
+ * from 300px to 540px.
  */
 export const FixedHeightIndicatorWraps: Story = {
   args: { maxRows: 1, containerWidth: 340, fixedHeight: true },
 };
 
 /**
- * Control: same growth, height left elastic. Wrapping makes the list taller, its ResizeObserver fires, a
- * new measuring pass runs, and the row count snaps back to 1. This is why the bug looks intermittent and
- * engine-specific in the wild.
+ * Control: same growth, height left elastic. This one was already correct before the fix — wrapping makes
+ * the list taller, its ResizeObserver fires, and a new pass restores one row. Which is why the bug looked
+ * intermittent and engine-specific in the wild.
  */
 export const ElasticHeightSelfHeals: Story = {
   args: { maxRows: 1, containerWidth: 340, fixedHeight: false },
 };
 
-/** The same staleness with two rows allowed, to show the violation is about `maxRows`, not about "1". */
+/**
+ * The same case with two rows allowed, to show the constraint honoured is `maxRows` and not "1". Expected:
+ * two rows throughout, never three.
+ */
 export const FixedHeightMaxRows2: Story = {
   args: { maxRows: 2, containerWidth: 260, fixedHeight: true },
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-overflow-list",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "description": "A responsive React component that shows as many items as can fit within constraints, hiding overflow items behind a configurable overflow renderer",
   "module": "./dist/index.js",

--- a/src/hooks/useOverflowList.ts
+++ b/src/hooks/useOverflowList.ts
@@ -11,7 +11,7 @@
 
 import { useRef, useState } from "react";
 
-import { getRowPositionsData } from "../utils";
+import { getContentFootprint, getRowPositionsData } from "../utils";
 import { useIsoLayoutEffect } from "./useIsoLayoutEffect";
 import { useResizeObserver } from "./useResizeObserver";
 
@@ -174,6 +174,44 @@ export function useOverflowList<
       setSubtractCount(0);
     }
   }, [containerDims]);
+
+  // The container's ResizeObserver only reports the container's *own* box. Items that change size while
+  // the container's box stays put (a counter badge growing from `9` to `10` in a fixed-height tab bar)
+  // therefore never trigger a new pass, and the visible count stays stale — see
+  // https://github.com/Eliav2/react-responsive-overflow-list/issues/21.
+  //
+  // So while settled, keep the footprint we settled at and compare it after every render. Any difference
+  // means the items are no longer the size the current visible count was chosen for, in either direction:
+  // grown past the row, or shrunk so that more of them would now fit.
+  //
+  // Deliberately has no dependency array — the whole point is to run on every commit, since the size
+  // change that matters is invisible to any dependency we could list. Recording and comparing both read
+  // the same settled DOM, so a pass that changes nothing externally records a matching footprint and does
+  // not re-enter measuring.
+  const settledFootprintRef = useRef<{ width: number; height: number } | null>(null);
+  useIsoLayoutEffect(() => {
+    if (phase !== "normal") {
+      // Mid-pass: whatever we recorded belongs to the previous settled layout.
+      settledFootprintRef.current = null;
+      return;
+    }
+
+    const footprint = getContentFootprint(containerRef);
+    if (!footprint) return;
+
+    const settled = settledFootprintRef.current;
+    if (!settled) {
+      settledFootprintRef.current = footprint;
+      return;
+    }
+
+    // Sub-pixel tolerance, so fractional layout jitter does not keep re-measuring.
+    if (Math.abs(footprint.width - settled.width) > 0.5 || Math.abs(footprint.height - settled.height) > 0.5) {
+      settledFootprintRef.current = null;
+      setPhase("measuring");
+      setSubtractCount(0);
+    }
+  });
 
   return {
     containerRef,

--- a/src/hooks/useOverflowList.ts
+++ b/src/hooks/useOverflowList.ts
@@ -11,7 +11,7 @@
 
 import { useRef, useState } from "react";
 
-import { getContentFootprint, getRowPositionsData } from "../utils";
+import { getContentSignature, getRowPositionsData } from "../utils";
 import { useIsoLayoutEffect } from "./useIsoLayoutEffect";
 import { useResizeObserver } from "./useResizeObserver";
 
@@ -180,34 +180,37 @@ export function useOverflowList<
   // therefore never trigger a new pass, and the visible count stays stale — see
   // https://github.com/Eliav2/react-responsive-overflow-list/issues/21.
   //
-  // So while settled, keep the footprint we settled at and compare it after every render. Any difference
-  // means the items are no longer the size the current visible count was chosen for, in either direction:
-  // grown past the row, or shrunk so that more of them would now fit.
+  // So while settled, keep a signature of the sizes we settled at and compare it after every render. Any
+  // difference means the items are no longer the size the current visible count was chosen for, in either
+  // direction: grown past the row, or shrunk so that more of them would now fit.
   //
   // Deliberately has no dependency array — the whole point is to run on every commit, since the size
   // change that matters is invisible to any dependency we could list. Recording and comparing both read
-  // the same settled DOM, so a pass that changes nothing externally records a matching footprint and does
+  // the same settled DOM, so a pass that changes nothing externally records a matching signature and does
   // not re-enter measuring.
-  const settledFootprintRef = useRef<{ width: number; height: number } | null>(null);
+  const settledSignatureRef = useRef<{ width: number; height: number } | null>(null);
   useIsoLayoutEffect(() => {
     if (phase !== "normal") {
       // Mid-pass: whatever we recorded belongs to the previous settled layout.
-      settledFootprintRef.current = null;
+      settledSignatureRef.current = null;
       return;
     }
 
-    const footprint = getContentFootprint(containerRef);
-    if (!footprint) return;
+    const signature = getContentSignature(containerRef);
+    if (!signature) return;
 
-    const settled = settledFootprintRef.current;
+    const settled = settledSignatureRef.current;
     if (!settled) {
-      settledFootprintRef.current = footprint;
+      settledSignatureRef.current = signature;
       return;
     }
 
-    // Sub-pixel tolerance, so fractional layout jitter does not keep re-measuring.
-    if (Math.abs(footprint.width - settled.width) > 0.5 || Math.abs(footprint.height - settled.height) > 0.5) {
-      settledFootprintRef.current = null;
+    // Compared exactly, with no tolerance. An unchanged layout reads back bit-identical (measured: zero
+    // drift over 300 frames), while a real change can be tiny — a counter going from `5` to `6` in a font
+    // with proportional digits, `system-ui` included, moves the width by as little as 0.008px. Any
+    // tolerance would discard those to guard against jitter that does not occur.
+    if (signature.width !== settled.width || signature.height !== settled.height) {
+      settledSignatureRef.current = null;
       setPhase("measuring");
       setSubtractCount(0);
     }

--- a/src/hooks/useOverflowList.ts
+++ b/src/hooks/useOverflowList.ts
@@ -11,7 +11,7 @@
 
 import { useRef, useState } from "react";
 
-import { getContentSignature, getRowPositionsData } from "../utils";
+import { getContentSignature, getRowPositionsData, isSameContentSignature } from "../utils";
 import { useIsoLayoutEffect } from "./useIsoLayoutEffect";
 import { useResizeObserver } from "./useResizeObserver";
 
@@ -188,7 +188,7 @@ export function useOverflowList<
   // change that matters is invisible to any dependency we could list. Recording and comparing both read
   // the same settled DOM, so a pass that changes nothing externally records a matching signature and does
   // not re-enter measuring.
-  const settledSignatureRef = useRef<{ width: number; height: number } | null>(null);
+  const settledSignatureRef = useRef<number[] | null>(null);
   useIsoLayoutEffect(() => {
     if (phase !== "normal") {
       // Mid-pass: whatever we recorded belongs to the previous settled layout.
@@ -209,7 +209,7 @@ export function useOverflowList<
     // drift over 300 frames), while a real change can be tiny — a counter going from `5` to `6` in a font
     // with proportional digits, `system-ui` included, moves the width by as little as 0.008px. Any
     // tolerance would discard those to guard against jitter that does not occur.
-    if (signature.width !== settled.width || signature.height !== settled.height) {
+    if (!isSameContentSignature(signature, settled)) {
       settledSignatureRef.current = null;
       setPhase("measuring");
       setSubtractCount(0);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -42,6 +42,52 @@ export function groupNodesByTopPosition(nodes: HTMLElement[]): Record<number, No
 }
 
 /**
+ * Whether a container child takes part in the flex flow, and therefore in row layout.
+ */
+function isLaidOutInFlow(child: Element): boolean {
+  // A child with no client rects is not laid out at all — `display: none`, the `hidden` attribute, or
+  // an overflowed item kept mounted but hidden (that is what React 19.2's `Activity mode="hidden"`
+  // does, and it is the default `renderItemVisibility`). Its rect reads as all zeros, so it would be
+  // grouped into a phantom row keyed at top 0.
+  if (child.getClientRects().length === 0) return false;
+
+  // An out-of-flow child is not a flex item, so it never takes part in a row either. Popover
+  // libraries put focus guards next to an open trigger this way (Base UI wraps the trigger in
+  // `position: fixed` 1px spans), and their top lands outside the items' row.
+  const { position } = getComputedStyle(child);
+  if (position === "absolute" || position === "fixed") return false;
+
+  return true;
+}
+
+/**
+ * Total size of everything currently laid out in the container, the overflow indicator included.
+ *
+ * Used as a change signal, not as a measurement: measurement is only re-triggered when the container's
+ * own box changes or when `itemCount`/`maxRows` change, so items that change size on their own (a counter
+ * badge growing from `9` to `10`, say) leave the visible count stale. Usually the wrap that follows makes
+ * the container taller and its ResizeObserver rescues us, but when the container's box is fixed — an
+ * ordinary tab bar — nothing ever re-triggers a pass. Comparing this value across renders catches both
+ * directions: items growing past the row, and items shrinking so more of them would now fit.
+ */
+export function getContentFootprint(
+  containerRef: React.RefObject<HTMLElement | null>,
+): { width: number; height: number } | null {
+  if (!containerRef.current) return null;
+
+  let width = 0;
+  let height = 0;
+  for (const child of Array.from(containerRef.current.children)) {
+    if (!isLaidOutInFlow(child)) continue;
+    const rect = child.getBoundingClientRect();
+    width += rect.width;
+    height += rect.height;
+  }
+
+  return { width, height };
+}
+
+/**
  * Helper function to get row information from container
  * Returns itemsSizesMap, rowPositions, and children or null if the container is not available
  */
@@ -56,23 +102,9 @@ export function getRowPositionsData(
   if (!containerRef.current) return null;
 
   const container = containerRef.current;
-  const children = Array.from(container.children).filter((child) => {
-    if (overflowRef.current === child) return false;
-
-    // A child with no client rects is not laid out at all — `display: none`, the `hidden` attribute, or
-    // an overflowed item kept mounted but hidden (that is what React 19.2's `Activity mode="hidden"`
-    // does, and it is the default `renderItemVisibility`). Its rect reads as all zeros, so it would be
-    // grouped into a phantom row keyed at top 0.
-    if (child.getClientRects().length === 0) return false;
-
-    // An out-of-flow child is not a flex item, so it never takes part in a row either. Popover
-    // libraries put focus guards next to an open trigger this way (Base UI wraps the trigger in
-    // `position: fixed` 1px spans), and their top lands outside the items' row.
-    const { position } = getComputedStyle(child);
-    if (position === "absolute" || position === "fixed") return false;
-
-    return true;
-  }) as HTMLElement[];
+  const children = Array.from(container.children).filter(
+    (child) => overflowRef.current !== child && isLaidOutInFlow(child),
+  ) as HTMLElement[];
 
   // Row keys are read in ascending numeric order, so any of the children filtered out above would sort
   // ahead of the real items and be measured as the first row — which reports a visible count of however

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,27 +61,38 @@ function isLaidOutInFlow(child: Element): boolean {
 }
 
 /**
- * Total size of everything currently laid out in the container, the overflow indicator included.
+ * Signature of the sizes of everything currently laid out in the container, the overflow indicator
+ * included. Not a measurement — only a value to compare against itself across renders.
  *
- * Used as a change signal, not as a measurement: measurement is only re-triggered when the container's
- * own box changes or when `itemCount`/`maxRows` change, so items that change size on their own (a counter
- * badge growing from `9` to `10`, say) leave the visible count stale. Usually the wrap that follows makes
- * the container taller and its ResizeObserver rescues us, but when the container's box is fixed — an
- * ordinary tab bar — nothing ever re-triggers a pass. Comparing this value across renders catches both
- * directions: items growing past the row, and items shrinking so more of them would now fit.
+ * Measurement is re-triggered when the container's own box changes or when `itemCount`/`maxRows` change,
+ * so items that change size on their own (a counter badge growing from `9` to `10`, say) leave the visible
+ * count stale. Usually the wrap that follows makes the container taller and its ResizeObserver rescues us,
+ * but when the container's box is fixed — an ordinary tab bar — nothing ever re-triggers a pass. Comparing
+ * this signature catches both directions: items growing past the row, and items shrinking so that more of
+ * them would now fit.
+ *
+ * Each size is weighted by the child's position, so that changes cancelling out across items are still
+ * seen. A plain total would miss them, and a total is not sufficient: which items fit is decided by the
+ * running sum along the row, not by the sum of all of them. At capacity 120, widths `[40, 40, 40]` fit two
+ * items while `[90, 20, 10]` fit one, on the same total.
+ *
+ * Values stay exact under comparison: engines lay out on a fractional-pixel grid (1/64px in Chromium), and
+ * scaling those by a small integer and summing them is exactly representable in a double.
  */
-export function getContentFootprint(
+export function getContentSignature(
   containerRef: React.RefObject<HTMLElement | null>,
 ): { width: number; height: number } | null {
   if (!containerRef.current) return null;
 
   let width = 0;
   let height = 0;
+  let position = 0;
   for (const child of Array.from(containerRef.current.children)) {
     if (!isLaidOutInFlow(child)) continue;
+    position += 1;
     const rect = child.getBoundingClientRect();
-    width += rect.width;
-    height += rect.height;
+    width += rect.width * position;
+    height += rect.height * position;
   }
 
   return { width, height };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -61,8 +61,8 @@ function isLaidOutInFlow(child: Element): boolean {
 }
 
 /**
- * Signature of the sizes of everything currently laid out in the container, the overflow indicator
- * included. Not a measurement — only a value to compare against itself across renders.
+ * Sizes of everything currently laid out in the container, in order, the overflow indicator included. Not
+ * a measurement — only a value to compare against itself across renders.
  *
  * Measurement is re-triggered when the container's own box changes or when `itemCount`/`maxRows` change,
  * so items that change size on their own (a counter badge growing from `9` to `10`, say) leave the visible
@@ -71,31 +71,39 @@ function isLaidOutInFlow(child: Element): boolean {
  * this signature catches both directions: items growing past the row, and items shrinking so that more of
  * them would now fit.
  *
- * Each size is weighted by the child's position, so that changes cancelling out across items are still
- * seen. A plain total would miss them, and a total is not sufficient: which items fit is decided by the
- * running sum along the row, not by the sum of all of them. At capacity 120, widths `[40, 40, 40]` fit two
- * items while `[90, 20, 10]` fit one, on the same total.
+ * Kept as the ordered sequence of sizes rather than reduced to a total, because no scalar can stand in for
+ * it. Which items fit is decided by the running sum along the row, not by the sum of all of them: at
+ * capacity 100, widths `[40, 60]` fit both items while `[50, 55]` fit one. Any accumulation collides on
+ * pairs like those — a plain total misses two counters swapping values, and weighting each size by its
+ * position still maps `[40, 60]` and `[50, 55]` to the same number.
  *
- * Values stay exact under comparison: engines lay out on a fractional-pixel grid (1/64px in Chromium), and
- * scaling those by a small integer and summing them is exactly representable in a double.
+ * Collecting the sizes rather than accumulating them costs nothing measurable; the `getBoundingClientRect`
+ * and `getComputedStyle` reads dominate either way. The sequence is also short: this only runs once
+ * settled, where the overflowed items are hidden and excluded, so its length tracks the visible count.
  */
-export function getContentSignature(
-  containerRef: React.RefObject<HTMLElement | null>,
-): { width: number; height: number } | null {
+export function getContentSignature(containerRef: React.RefObject<HTMLElement | null>): number[] | null {
   if (!containerRef.current) return null;
 
-  let width = 0;
-  let height = 0;
-  let position = 0;
+  const signature: number[] = [];
   for (const child of Array.from(containerRef.current.children)) {
     if (!isLaidOutInFlow(child)) continue;
-    position += 1;
     const rect = child.getBoundingClientRect();
-    width += rect.width * position;
-    height += rect.height * position;
+    signature.push(rect.width, rect.height);
   }
 
-  return { width, height };
+  return signature;
+}
+
+/**
+ * Compares two content signatures. Length first: comparing only by index would silently treat a truncated
+ * sequence as unchanged.
+ */
+export function isSameContentSignature(a: number[], b: number[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
 }
 
 /**


### PR DESCRIPTION
Fixes #21.

## Root cause

Measurement is re-triggered by exactly two things: `[itemCount, maxRows]` changing, and the container's own `ResizeObserver`. Items that change size *on their own* match neither — a counter badge going `9` → `10` widens the items without adding one and without touching the container's width. `visibleCount` stays at whatever fit before, the wider items no longer fit beside the indicator, and the indicator wraps to a second row in violation of `maxRows`.

**Why it reads as intermittent and Firefox-specific:** the component usually rescues itself. The wrap makes the container *taller*, `useResizeObserver` reports the height change (it watches both dimensions), and a fresh pass runs. The bug is only visible when the container's box **cannot** change — the ordinary shape of a tab bar, a fixed height. Then nothing ever re-triggers a pass and the second row is permanent.

So it is probably not the engine at all, but whether the container's box is free to change in the surrounding layout. @author-of-21 — does your tab bar have a fixed height? That would confirm it.

Ruled out along the way: comparing `items` identity instead of `itemCount` would not have helped. In the repro `items` is a constant array; the badge count arrives through the `renderItem` closure.

## Fix

Record the content footprint when a pass settles; compare it after every commit.

```ts
const footprint = getContentFootprint(containerRef);
if (!settled) { settledFootprintRef.current = footprint; return; }
if (Math.abs(footprint.width - settled.width) > 0.5 || Math.abs(footprint.height - settled.height) > 0.5) {
  settledFootprintRef.current = null;
  setPhase("measuring");
  setSubtractCount(0);
}
```

Design notes:

- **Comparing beats an invariant check.** `rows > maxRows` would only catch the grow direction. Items *shrinking* leaves rows within `maxRows` while fewer items show than fit — same bug, invisible to that test. Comparing catches both.
- **No dependency array, on purpose.** The size change that matters is invisible to any dependency that could be listed.
- **Loop-safe by construction.** Recording and comparing read the same settled DOM, so a pass that changes nothing externally records a matching footprint and does not re-enter measuring. Termination still rests on the existing `finalVisibleCount <= 0` guard.
- **No churn from focus guards.** The footprint reuses row measurement's child predicate, now extracted as `isLaidOutInFlow`, so out-of-flow and non-laid-out children are excluded — the #23 case.
- **Cheap.** One `getBoundingClientRect` loop over the *visible* children per render, versus a full measuring pass which renders every item.

### Why not a ResizeObserver on the children

Cost is not the objection — one RO instance observes N elements and batches all entries into a single per-frame callback; a few dozen tabs is noise. The objection is feedback: our own machinery resizes the children (`normal` phase hides overflowed items with `display: none` → size 0 → RO fires), so every settle generates events that must be filtered by phase, by zero-size, and against per-element last-known sizes. That is real loop surface in a component whose history already includes #4 (constant rerendering).

Its only unique value is size changes with **no React render** — web-font load, late image, CSS transition. Real but rarer, and it can land separately on top of this. The footprint check covers #21 because the counters are React state, so a commit always happens.

## Testing

Chromium, real `ResizeObserver`, new `Issues/Issue21 - Dynamic Item Widths` story.

**Before**, fixed height at 340px, `maxRows={1}`:

| stage | rendered | rows |
| --- | --- | --- |
| no badge | Overview / Assets / Issues / More (2) | 1 |
| badge appears (1) | Overview1 / Assets1 / Issues1 / More (2) | **2** |
| … through `99+` | Overview99+ / Assets99+ / Issues99+ / More (2) | **2** |

Broken at all 25 widths from 300px to 540px. `Remount` cleared it, confirming stale state rather than faulty measurement.

**After** — the grow direction drops an item into overflow instead of wrapping, and the shrink direction restores it:

| stage | growing | shrinking back |
| --- | --- | --- |
| no badge | Overview / Assets / Issues / More (2) | Overview / Assets / Issues / More (2) |
| badge (1) | Overview1 / Assets1 / More (3) | Overview1 / Assets1 / More (3) |
| `99+` | Overview99+ / Assets99+ / More (3) | — |

- **Exhaustive sweep:** 16 widths (260-560px) × 6 stages = 96 combinations, **zero** `maxRows` violations.
- **Stress:** 24 interleaved width jumps and stage steps, then settles to 1 row with **0** DOM mutations over 1s.
- **No render loop anywhere:** 0 mutations over 1s on all 8 stories, including `Issues/Issue #4` (the constant-rerendering repro) — the story most at risk from a dependency-array-free effect.
- **No regression:** `Examples/DifferentHeights` (Basic + Multi Row), `Example/HelloWorld`, `Issues/Issue17`, `Issues/Issue #4` render byte-identical text before and after. `Issues/Non-Item Children` is byte-identical across its whole width sweep, and opening its live popover (3 focus guards mounted) produces 0 mutations.
- `pnpm build` (incl. `attw` + `publint`), `pnpm type-check`, demo `tsc -b` and `eslint` on the new story all pass.

Not verified in Firefox — no Firefox automation available here. The mechanism is not browser-specific, but a check there is welcome.

## Known gap

Size changes that produce no React render (web-font swap, late-loading image) are still missed. That is the RO-on-children follow-up, deliberately out of scope here.

## Note

Version bumped to 0.4.3, so merging this will trigger the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed stale visible-item counts when item dimensions change without resizing the container.
  - Improved detection of both growing and shrinking content while respecting maximum row limits.

- **Documentation**
  - Added changelog entry for version 0.4.3.

- **Demo**
  - Added interactive examples demonstrating dynamic item widths, wrapping, row limits, and automatic layout recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->