### PR TITLE
feat(demo): publish Storybook alongside the demo site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,15 @@ jobs:
 
       - name: Type-check demo
         run: pnpm --filter demo exec tsc -b
+
+      - name: Build Storybook
+        run: pnpm --filter demo build:storybook
+
+      # `storybook build` exits 0 having emitted only the manager when its Vite config is wrong — that is how
+      # it behaved while it was picking up the demo's tanstack-start config. Assert the story preview and the
+      # story index actually exist, or a broken Storybook ships silently.
+      - name: Verify the Storybook preview was built
+        run: |
+          test -f demo/public/storybook/iframe.html
+          test -f demo/public/storybook/index.json
+          node -e "const n=Object.keys(require('./demo/public/storybook/index.json').entries).length; if(!n) throw new Error('no stories indexed'); console.log(n+' stories indexed')"

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ coverage/
 # Temporary
 .tmp/
 temp/
+
+# Storybook build. Emitted into the demo public directory so the demo build serves it at /storybook.
+demo/public/storybook/
+storybook-static/

--- a/demo/.storybook/main.ts
+++ b/demo/.storybook/main.ts
@@ -1,13 +1,26 @@
-import type { StorybookConfig } from '@storybook/react-vite';
+import type { StorybookConfig } from "@storybook/react-vite";
+
+// Storybook is published as a subdirectory of the demo site, so its assets are requested from
+// `<demo base>/storybook/`. The demo is served from the root on Netlify and from the repository name on
+// GitHub Pages, so the base is derived the same way demo/vite.config.ts derives its own.
+const isGithubPages = process.env.GITHUB_PAGES === "true";
+const demoBase = isGithubPages ? "/react-responsive-overflow-list/" : "/";
 
 const config: StorybookConfig = {
-  "stories": [
-    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"
-  ],
-  "addons": [],
-  "framework": {
-    "name": "@storybook/react-vite",
-    "options": {}
-  }
+  stories: ["../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
+  addons: [],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {
+      // Without this Storybook loads demo/vite.config.ts, whose tanstack-start and nitro plugins hijack the
+      // build and emit the demo app instead of a story preview. See ./vite.config.ts.
+      builder: { viteConfigPath: ".storybook/vite.config.ts" },
+    },
+  },
+  viteFinal(viteConfig) {
+    viteConfig.base = `${demoBase}storybook/`;
+    return viteConfig;
+  },
 };
+
 export default config;

--- a/demo/.storybook/vite.config.ts
+++ b/demo/.storybook/vite.config.ts
@@ -1,0 +1,28 @@
+// Vite config used only by Storybook.
+//
+// Storybook otherwise picks up demo/vite.config.ts, whose tanstack-start and nitro plugins take over the
+// build: `storybook build` then emits the demo app into .output/public and produces no story preview at all
+// (no iframe.html), while still exiting successfully. So Storybook gets its own config with just what the
+// stories need.
+
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import tailwindcss from "@tailwindcss/vite";
+import viteReact from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+const demoDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+export default defineConfig({
+  // Storybook is built into demo/public/storybook, so leaving publicDir on would have it copy the public
+  // directory into a subdirectory of itself.
+  publicDir: false,
+  plugins: [viteReact(), tailwindcss()],
+  resolve: {
+    alias: {
+      "@": resolve(demoDir, "./src"),
+    },
+    // Same reason as demo/vite.config.ts: two react-dom copies make the library's flushSync a silent no-op.
+    dedupe: ["react", "react-dom"],
+  },
+});

--- a/demo/package.json
+++ b/demo/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "prebuild": "pnpm -w sync:registry && pnpm -w build:registry",
+    "prebuild": "pnpm -w sync:registry && pnpm -w build:registry && pnpm build:storybook",
     "dev": "vite dev --port 3000",
     "dev:local": "pnpm install --link-workspace-packages && pnpm dev",
     "dev:published": "pnpm install --no-link-workspace-packages && pnpm dev",
@@ -14,7 +14,8 @@
     "preview": "vite preview",
     "start": "node .output/server/index.mjs",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "build:storybook": "storybook build -o public/storybook"
   },
   "dependencies": {
     "@base-ui/react": "^1.1.0",

--- a/demo/src/components/layout/Header.tsx
+++ b/demo/src/components/layout/Header.tsx
@@ -26,6 +26,13 @@ export function Header({ sidebarOpen, onToggleSidebar }: HeaderProps) {
           </Link>
         </div>
         <div className="flex items-center gap-3">
+          {/* Not a router Link: Storybook is a separate build served as a static subdirectory of this site. */}
+          <a
+            href={`${import.meta.env.BASE_URL}storybook/`}
+            className="text-sm text-gray-600 no-underline hover:text-gray-900 transition-colors"
+          >
+            Storybook
+          </a>
           <a
             href="https://github.com/eliav2/react-responsive-overflow-list"
             target="_blank"


### PR DESCRIPTION
Publishes Storybook as `/storybook` on the demo site, so deploy previews can show the stories.

## Why

The stories are the only place the measurement behaviour is visible in a real browser, and nothing published them. Netlify builds the docs app; GitHub Pages deploys the same output. So the repros added for #21 and #23 existed only on a developer's machine — a deploy preview could show that the demo still worked, but never the bug the change was about.

## Two problems this had to solve

**1. Storybook was building the wrong thing, silently.**

`storybook build` loads the project's `vite.config.ts` by default. The demo's has `tanstackStart()` and `nitro()`, which took over the build: Storybook emitted **the demo app** into `.output/public`, produced **no story preview at all** (no `iframe.html`, no `assets/`), and **exited 0**.

Fixed by giving Storybook its own config at `.storybook/vite.config.ts`, carrying only what the stories need — React, Tailwind, the `@` alias, and the `react-dom` dedupe that keeps the library's `flushSync` from becoming a silent no-op. `publicDir: false` there, since the output now lands inside the public directory.

**2. The output had to land somewhere the host actually serves.**

`viteStaticCopy` writes to `demo/dist`, which nitro does not serve — that path was a dead end. `demo/public/*` is what ends up in `.output/public` (which is how `vite.svg` gets there), so Storybook builds straight into `demo/public/storybook`.

The base also has to match where the site is served from, since assets are requested from `<demo base>/storybook/`. Netlify serves from the root, GitHub Pages from the repository name, so `main.ts` derives it from `GITHUB_PAGES` exactly as `demo/vite.config.ts` derives its own.

## Verified end to end

Not just that files exist — that it serves and renders:

```
/                       200
/storybook/             200
/storybook/iframe.html  200
/storybook/index.json   200
/storybook/assets/iframe-Dy-5ECWO.js   200   (the asset iframe.html actually references)
```

Then loaded `Issues/Issue21 › FixedHeightIndicatorWraps` from the served build and stepped it: stage 1 → `Overview / Assets / Issues / More (2)`, stage 6 → `Overview99+ / Assets99+ / More (3)`, `measured rows: 1` throughout. So the published bundle carries working stories, not just a shell. 9 stories indexed.

## CI

Builds Storybook and asserts `iframe.html`, `index.json`, and a non-zero story count. That silent-success failure mode is otherwise invisible until someone opens the page, and it is exactly what happened here during development.

## Also

The demo's `prebuild` runs the Storybook build, so the two cannot fall out of step, and the header links to `/storybook`. `demo/public/storybook/` is gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Storybook link to the demo header for easier access to component previews.
  * Storybook is now built and available under the demo’s `/storybook/` path.
* **Bug Fixes**
  * Improved Storybook hosting support for root and GitHub Pages deployments.
* **Tests**
  * Builds now verify that Storybook generates the expected preview, story index, and indexed stories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->