### PR TITLE
feat: add observeItemSizes, fix unchanged-box re-measure churn

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ See the **Flush Immediately** example in the live demo.
 | `renderOverflowProps`  | `Partial<OverflowElementProps<T>>`                               | —            | Props for default overflow.                                                                                   |
 | `flushImmediately`     | `boolean`                                                        | `true`       | `true` (flushSync, no flicker) vs `false` (rAF, faster under resize).                                         |
 | `renderItemVisibility` | `(node: ReactNode, meta: RenderItemVisibilityMeta) => ReactNode` | internal     | Control visibility of hidden items (defaults to `React.Activity` if available, otherwise simply return null). |
+| `observeItemSizes`     | `boolean`                                                        | `false`      | Also re-measure when an item's own size changes with no render (web font swap, image load, CSS transition, drag handle). Costs one `ResizeObserver` over the children. |
 
 **Styles:** Root uses `display:flex; flex-wrap:wrap; align-items:center;`. Override via `style`/`className`.
 
@@ -182,6 +183,7 @@ export function CustomChipBar() {
 | `maxRows`          | `number`  | `1`     | Visible rows before overflow.                              |
 | `maxVisibleItems`  | `number`  | `100`   | Hard cap on visible items.                                 |
 | `flushImmediately` | `boolean` | `true`  | `true` (flushSync, no flicker) vs `false` (rAF, smoother). |
+| `observeItemSizes` | `boolean` | `false` | Re-measure on item-driven size changes that skip React entirely. |
 
 ### Hook return
 
@@ -216,6 +218,19 @@ It’s **expected** you’ll wrap `OverflowList` for product needs (design syste
 
 `flushImmediately=true` → immediate, flicker-free (uses `flushSync`).
 `flushImmediately=false` → defer with rAF; smoother under rapid resize, may flicker.
+
+### When measurement re-runs
+
+- **every render** — item sizes are compared against the sizes the current count was chosen for, and a pass
+  runs if they differ
+- **container resize**
+- **children resize** — only with `observeItemSizes`
+
+The first two miss size changes React is not involved in: a web font swapping in, an image loading, a CSS
+transition, a drag handle. `observeItemSizes` covers those, off by default. A re-measure waits for one
+animation frame with no further size change, so a drag or animation costs one pass when it stops rather than
+one per frame; measured at 100 items, frame times while dragging match leaving it off. Toggle it live in the
+`Behaviour/ResizableChildren` stories.
 
 ### Edge cases handled
 

--- a/demo/.storybook/preview.ts
+++ b/demo/.storybook/preview.ts
@@ -1,5 +1,10 @@
 import type { Preview } from '@storybook/react-vite'
 
+// The Storybook vite config runs the tailwind plugin, but nothing imported the stylesheet, so every Tailwind
+// class in every story was inert. The demo app pulls these in from its root route.
+import '../src/index.css'
+import '../src/shadcn.css'
+
 const preview: Preview = {
   parameters: {
     controls: {

--- a/demo/src/examples/ObserveItemSizesExample.tsx
+++ b/demo/src/examples/ObserveItemSizesExample.tsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState } from "react";
+import { OverflowList } from "react-responsive-overflow-list";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { tomorrow } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { ExampleCard } from "../components/ExampleCard";
+
+const items = ["Overview", "Assets", "Issues", "Policies", "Reports", "Settings", "Audit", "Billing"];
+
+/** Native resize handle. `resize` needs an overflow other than `visible` and a block-level box. */
+const ITEM_STYLES: React.CSSProperties = {
+  display: "inline-block",
+  overflow: "hidden",
+  resize: "horizontal",
+  minWidth: 40,
+  padding: "4px 8px",
+  border: "1px dashed #94a3b8",
+  borderRadius: 9999,
+  background: "#f1f5f9",
+  fontSize: "0.875rem",
+  whiteSpace: "nowrap",
+};
+
+/** Starting width of the resizable box. Reset restores this rather than clearing the inline width, since
+ * clearing it would drop React's own value too and let the box grow to fill the page. */
+const BOX_WIDTH = 340;
+
+const codeSample = `// Off by default. Turn it on when item sizes can change without a render:
+// a web font swapping in, an image inside an item loading, a CSS transition, a drag handle.
+<OverflowList
+  items={items}
+  observeItemSizes
+  renderItem={(item) => <span style={ITEM_STYLES}>{item}</span>}
+  renderOverflow={(hidden) => <span>+{hidden.length}</span>}
+  style={{ gap: 8 }}
+/>`;
+
+export function ObserveItemSizesExample() {
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const readoutRef = useRef<HTMLPreElement | null>(null);
+  const boxRef = useRef<HTMLDivElement | null>(null);
+  const [observeItemSizes, setObserveItemSizes] = useState(false);
+  // Dragging writes inline widths that React does not own, so it will not undo them on a re-render. Changing
+  // this key remounts the items, which is the only way back to the starting widths.
+  const [resetKey, setResetKey] = useState(0);
+
+  const reset = () => {
+    if (boxRef.current) boxRef.current.style.width = `${BOX_WIDTH}px`;
+    setResetKey((key) => key + 1);
+  };
+
+  // Written straight into the DOM on every frame. Deliberately not React state: a `setState` here would
+  // re-render the list, and a render is itself enough to re-measure, so the whole point of the example would
+  // be hidden by its own readout.
+  useEffect(() => {
+    let frame = 0;
+
+    const tick = () => {
+      const list = listRef.current;
+      const readout = readoutRef.current;
+      if (list && readout) {
+        const laidOut = Array.from(list.children).filter(
+          (child) => child.getClientRects().length > 0 && getComputedStyle(child).position === "static",
+        );
+        const listBox = list.getBoundingClientRect();
+        const lastRight = laidOut.length
+          ? Math.round(laidOut[laidOut.length - 1].getBoundingClientRect().right - listBox.left)
+          : 0;
+        const rows = new Set(laidOut.map((child) => Math.round(child.getBoundingClientRect().top))).size;
+
+        readout.textContent = [
+          `showing     ${laidOut.map((child) => child.textContent).join("  ")}`,
+          `rows        ${rows}${rows > 1 ? "   <-- wrapped past one row" : ""}`,
+          `free space  ${Math.round(listBox.width) - lastRight}px of ${Math.round(listBox.width)}`,
+        ].join("\n");
+      }
+      frame = requestAnimationFrame(tick);
+    };
+
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, []);
+
+  return (
+    <ExampleCard id="observe-item-sizes-example" title="Items That Resize Without a Render">
+      <p style={{ marginBottom: "20px", color: "#666", fontSize: "0.9rem" }}>
+        Measurement re-runs on every render and whenever the container's own size changes. A size change React is not
+        involved in trips neither: a web font swapping in, an image inside an item loading, a CSS transition, or a drag
+        handle. <code>observeItemSizes</code> covers that with a ResizeObserver over the children, and is off by
+        default because most lists never need one.
+      </p>
+
+      <div className="code-preview">
+        <SyntaxHighlighter language="tsx" style={tomorrow}>
+          {codeSample}
+        </SyntaxHighlighter>
+      </div>
+
+      <div className="demo-container">
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center", marginBottom: 12 }}>
+          <button
+            onClick={() => setObserveItemSizes((on) => !on)}
+            style={{
+              padding: "4px 12px",
+              borderRadius: 6,
+              border: observeItemSizes ? "1px solid #059669" : "1px solid #cbd5e1",
+              background: observeItemSizes ? "#d1fae5" : "#fff",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+            }}
+          >
+            observeItemSizes: {observeItemSizes ? "ON" : "OFF"}
+          </button>
+          <button
+            onClick={reset}
+            style={{
+              padding: "4px 12px",
+              borderRadius: 6,
+              border: "1px solid #cbd5e1",
+              background: "#fff",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+            }}
+          >
+            Reset sizes
+          </button>
+          <span style={{ color: "#64748b", fontSize: "0.8rem" }}>
+            drag the corner of any item, or of the box around them
+          </span>
+        </div>
+
+        {/*
+          The container gets a handle too, for contrast. Dragging it changes the container's own box, which the
+          list already watches with nothing opted in, so it re-measures either way. Dragging an item changes
+          only a child, and that is the case the option exists for.
+        */}
+        <div
+          ref={boxRef}
+          style={{
+            width: BOX_WIDTH,
+            minWidth: 140,
+            maxWidth: "100%",
+            resize: "horizontal",
+            overflow: "hidden",
+            padding: 8,
+            border: "1px solid #cbd5e1",
+            borderRadius: 8,
+          }}
+        >
+          <OverflowList
+            key={resetKey}
+            ref={listRef}
+            items={items}
+            maxRows={1}
+            observeItemSizes={observeItemSizes}
+            style={{ gap: 8, height: 34, overflow: "hidden" }}
+            renderItem={(item: string) => <span style={ITEM_STYLES}>{item}</span>}
+            renderOverflow={(hidden: string[]) => (
+              <span
+                style={{
+                  padding: "4px 8px",
+                  border: "1px solid #94a3b8",
+                  borderRadius: 9999,
+                  background: "#fef3c7",
+                  fontSize: "0.875rem",
+                  whiteSpace: "nowrap",
+                }}
+              >
+                +{hidden.length}
+              </span>
+            )}
+          />
+        </div>
+
+        <pre
+          ref={readoutRef}
+          data-observe-item-sizes-readout
+          style={{
+            marginTop: 12,
+            padding: 8,
+            background: "#f1f5f9",
+            borderRadius: 6,
+            fontSize: "0.75rem",
+            lineHeight: 1.6,
+            whiteSpace: "pre-wrap",
+          }}
+        />
+
+        <div className="demo-note" style={{ marginTop: "12px" }}>
+          <strong>With it OFF:</strong> drag an item narrower and free space opens up while the indicator keeps
+          claiming the same hidden items. The list's height is pinned here, so it cannot notice its own box changing
+          and rescue itself. Dragging the outer box still works, because that is the container's own size.
+          <br />
+          <strong>With it ON:</strong> the count corrects a frame or two after you let go. It waits for the sizes to
+          hold still rather than re-measuring every frame, so dragging stays cheap.
+          <br />
+          <em>Note:</em> toggling is itself a render, and a render re-measures, so it heals the list on the way. Drag
+          again after toggling to see the difference.
+        </div>
+      </div>
+    </ExampleCard>
+  );
+}

--- a/demo/src/routes/docs/api.tsx
+++ b/demo/src/routes/docs/api.tsx
@@ -72,6 +72,13 @@ const allProps: PropDefinition[] = [
     description:
       "Control visibility of hidden items. Defaults to React.Activity (19.2+) or null.",
   },
+  {
+    name: "observeItemSizes",
+    type: "boolean",
+    default: "false",
+    description:
+      "Also re-measure when an item's own size changes with no render: a web font swapping in, an image loading, a CSS transition, a drag handle. Costs one ResizeObserver over the children, so it is opt-in.",
+  },
 ];
 
 function ApiPage() {

--- a/demo/src/routes/docs/examples.tsx
+++ b/demo/src/routes/docs/examples.tsx
@@ -12,6 +12,7 @@ import { FlushImmediatelyExample } from "../../examples/FlushImmediatelyExample"
 import { OneItemWiderExample } from "../../examples/OneItemWiderExample";
 import { ReverseOrderExample } from "../../examples/ReverseOrderExample";
 import { DynamicSizeExample } from "../../examples/DynamicSizeExample";
+import { ObserveItemSizesExample } from "../../examples/ObserveItemSizesExample";
 import { DifferentHeightsExample } from "../../examples/DifferentHeightsExample";
 import { HeadlessHookExample } from "../../examples/HeadlessHookExample";
 
@@ -41,6 +42,7 @@ function ExamplesPage() {
           <OneItemWiderExample />
           <ReverseOrderExample />
           <DynamicSizeExample />
+          <ObserveItemSizesExample />
           <DifferentHeightsExample />
         </div>
       </div>

--- a/demo/src/stories/ResizableChildren.stories.tsx
+++ b/demo/src/stories/ResizableChildren.stories.tsx
@@ -1,0 +1,232 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useEffect, useRef, useState } from "react";
+import { OverflowList } from "react-responsive-overflow-list";
+
+/**
+ * Hands you a drag handle on every item, so item sizes can be changed by hand with React uninvolved.
+ *
+ * Each item uses the browser's native `resize: horizontal`, which writes an inline width straight onto the
+ * DOM node. No state changes, no render. That is the point: measurement is re-triggered by `[itemCount,
+ * maxRows]`, by the container's own ResizeObserver, or by the content-signature check that runs on every
+ * commit. Dragging a handle trips none of them directly, so whether the list keeps up depends entirely on
+ * whether the drag happens to change the container's own box.
+ *
+ * `observeItemSizes` is the opt-in that closes that gap, and the toggle flips it live. Drag with it OFF to see
+ * the list go stale, then turn it on and drag again. Off is the default, because it means a ResizeObserver over
+ * every child, and most lists never need one.
+ *
+ * The container has a handle of its own, for contrast. Dragging it changes the container's own box, which the
+ * list already watches with nothing opted into, so it re-measures either way. Dragging an item changes only a
+ * child. Same gesture, and only one of the two is covered by default.
+ *
+ * Drag a handle (bottom-right corner of any item) and watch the readout. What to look for is in each story's
+ * description.
+ *
+ * The readout is written straight into the DOM from a requestAnimationFrame loop, and this component holds no
+ * state that changes while you drag. A `setState` here would re-render the list, the per-commit check would
+ * run, and the whole thing would appear to work.
+ */
+
+const LABELS = ["Overview", "Assets", "Issues", "Policies", "Reports", "Settings", "Audit", "Billing"];
+
+/** Repeats the label set up to `count`, so the same story can be run at a realistic list length. */
+function labelsFor(count: number): string[] {
+  return Array.from({ length: count }, (_, index) =>
+    index < LABELS.length ? LABELS[index] : `${LABELS[index % LABELS.length]} ${Math.floor(index / LABELS.length) + 1}`,
+  );
+}
+
+interface StoryProps {
+  /**
+   * Pin the height of the list element itself. A pinned list cannot report a size change of its own, which is
+   * the normal shape of a tab bar. It has to be the list element and not a wrapper: a pinned wrapper still
+   * lets the list grow to two rows inside it, and the list's own observer reports that.
+   */
+  pinListHeight?: boolean;
+  containerWidth: number;
+  maxRows?: number;
+  /** Starting value for the in-story toggle. */
+  observeItemSizes?: boolean;
+  /** How many items to render. Every pass costs one render per item, so this is what scales the cost. */
+  itemCount?: number;
+}
+
+function ResizableList({
+  pinListHeight,
+  containerWidth,
+  maxRows = 1,
+  observeItemSizes = false,
+  itemCount = LABELS.length,
+}: StoryProps) {
+  const items = labelsFor(itemCount);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const readoutRef = useRef<HTMLPreElement | null>(null);
+  // Remounting is the one thing here that is allowed to change state, and only between drags.
+  const [remountKey, setRemountKey] = useState(0);
+  // A render that does not remount. The dragged widths survive it, because they live as inline styles that
+  // React does not own, so this isolates the one thing a render adds: the per-commit signature check.
+  const [renderCount, setRenderCount] = useState(0);
+  // Flipping this is itself a render, so it heals the list on the way. Drag again afterwards to see the
+  // difference: that is what the button label says.
+  const [observing, setObserving] = useState(observeItemSizes);
+
+  useEffect(() => {
+    let frame = 0;
+
+    const tick = () => {
+      const list = listRef.current;
+      const readout = readoutRef.current;
+      if (list && readout) {
+        const children = Array.from(list.children) as HTMLElement[];
+        const laidOut = children.filter(
+          (child) => child.getClientRects().length > 0 && getComputedStyle(child).position === "static",
+        );
+        const rows = new Set(laidOut.map((child) => Math.round(child.getBoundingClientRect().top)));
+        const listBox = list.getBoundingClientRect();
+        const widths = laidOut.map((child) => Math.round(child.getBoundingClientRect().width));
+        const used = widths.reduce((total, width) => total + width, 0);
+        const lastRight = laidOut.length
+          ? Math.round(laidOut[laidOut.length - 1].getBoundingClientRect().right - listBox.left)
+          : 0;
+
+        readout.textContent = [
+          `showing        ${laidOut.map((child) => child.textContent).join("  ")}`,
+          `rows           ${rows.size}${rows.size > maxRows ? `   <-- OVER maxRows=${maxRows}` : ""}`,
+          `list box       ${Math.round(listBox.width)} x ${Math.round(listBox.height)}`,
+          `item widths    ${widths.join(" + ")} = ${used}`,
+          `last item ends ${lastRight} of ${Math.round(listBox.width)}${
+            lastRight > Math.round(listBox.width) ? "   <-- PAST THE EDGE" : ""
+          }`,
+          `free space     ${Math.round(listBox.width) - lastRight}`,
+          `container      ${Math.round(list.parentElement?.getBoundingClientRect().width ?? 0)} wide (drag its corner too)`,
+        ].join("\n");
+      }
+      frame = requestAnimationFrame(tick);
+    };
+
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [maxRows]);
+
+  return (
+    <div className="flex flex-col gap-3 p-4 font-sans">
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <button
+          className={`rounded border px-3 py-1 ${observing ? "border-emerald-600 bg-emerald-100" : "bg-white"}`}
+          onClick={() => setObserving((on) => !on)}
+        >
+          observeItemSizes: {observing ? "ON" : "OFF"}
+        </button>
+        <button className="rounded border px-3 py-1" onClick={() => setRenderCount((count) => count + 1)}>
+          Force re-render ({renderCount})
+        </button>
+        <button className="rounded border px-3 py-1" onClick={() => setRemountKey((key) => key + 1)}>
+          Remount ({remountKey})
+        </button>
+        <span className="text-slate-500">
+          drag the bottom-right corner of any <strong>item</strong>, or of the <strong>container</strong> box
+          itself. Toggling is a render, so it heals the list first: drag <em>after</em> toggling. Force
+          re-render keeps your widths; Remount resets them.
+        </span>
+      </div>
+
+      {/*
+        The container gets a handle too, so both invalidation paths are reachable by hand: dragging this one
+        changes the container's own box, which its ResizeObserver reports with no opt-in needed, while dragging
+        an item changes only a child. `resize` needs an overflow other than `visible` to offer a handle.
+      */}
+      <div
+        className="rounded border border-slate-300 p-2"
+        style={{ width: containerWidth, minWidth: 120, resize: "horizontal", overflow: "hidden" }}
+      >
+        <OverflowList
+          key={remountKey}
+          ref={listRef}
+          items={items}
+          maxRows={maxRows}
+          observeItemSizes={observing}
+          style={{
+            gap: 8,
+            ...(pinListHeight ? { height: maxRows * 40, overflow: "hidden" } : {}),
+          }}
+          renderItem={(label: string) => (
+            // `resize` needs an overflow other than `visible` and a block-level box to give a handle. Width is
+            // deliberately not set from React: the native handle writes an inline width, and a React-owned
+            // width would be reapplied on the next render and undo the drag.
+            <span
+              className="rounded border border-dashed border-slate-400 bg-slate-100 px-2 py-1 text-sm whitespace-nowrap"
+              style={{ display: "inline-block", overflow: "hidden", resize: "horizontal", minWidth: 40 }}
+            >
+              {label}
+            </span>
+          )}
+          renderOverflow={(hidden: string[]) => (
+            <span className="rounded border border-slate-400 bg-amber-100 px-2 py-1 text-sm whitespace-nowrap">
+              +{hidden.length}
+            </span>
+          )}
+        />
+      </div>
+
+      <pre ref={readoutRef} className="rounded bg-slate-100 p-2 text-xs leading-5 whitespace-pre-wrap" />
+    </div>
+  );
+}
+
+const meta = {
+  title: "Behaviour/ResizableChildren",
+  component: ResizableList,
+} satisfies Meta<typeof ResizableList>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Widen an item until the row cannot hold what is showing.
+ *
+ * The list's height is free to grow here, so the items wrap, the list gets taller, and its own
+ * ResizeObserver reports that. A pass runs and the count catches up. This is the self-heal that made #21 look
+ * intermittent: the list is not noticing the item, it is noticing itself.
+ */
+export const WidenAnItem: Story = {
+  args: { containerWidth: 340 },
+};
+
+/**
+ * Now shrink an item instead, and drag it well below its label width.
+ *
+ * Nothing wraps, so the list's box never changes and nothing re-triggers measurement. Free space opens up in
+ * the row while the indicator keeps claiming the same hidden items, and they do not come back. Watch `free
+ * space` in the readout climb with the indicator unchanged.
+ *
+ * The clearest one to try the toggle on: shrinking needs no pinned height to break, because shrinking never
+ * wraps, so there is no self-heal to hide behind. With `observeItemSizes` on, the hidden items come back about
+ * a frame or two after you let go of the handle.
+ */
+export const ShrinkAnItem: Story = {
+  args: { containerWidth: 340 },
+};
+
+/**
+ * Widen an item with the list's own height pinned, the shape of a fixed-height tab bar.
+ *
+ * The self-heal above is gone: the list cannot report a size change, so widening past the edge stays broken.
+ * Watch `last item ends` go past the list width and stay there. Turning `observeItemSizes` on fixes it.
+ */
+export const WidenWithPinnedHeight: Story = {
+  args: { containerWidth: 340, pinListHeight: true },
+};
+
+/** Same, with two rows allowed, in case the single-row case reads as a special case. */
+export const WidenWithPinnedHeightTwoRows: Story = {
+  args: { containerWidth: 340, pinListHeight: true, maxRows: 2 },
+};
+
+/**
+ * The same thing at a list length where cost is measurable. Every pass renders every item, so this is where
+ * re-measuring too eagerly shows up as dropped frames while you drag.
+ */
+export const HundredItemsPinnedHeight: Story = {
+  args: { containerWidth: 340, pinListHeight: true, itemCount: 100 },
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-responsive-overflow-list",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "type": "module",
   "description": "A responsive React component that shows as many items as can fit within constraints, hiding overflow items behind a configurable overflow renderer",
   "module": "./dist/index.js",

--- a/src/components/OverflowList.tsx
+++ b/src/components/OverflowList.tsx
@@ -33,6 +33,12 @@ type BaseOverflowListProps<T> = BaseComponentProps & {
 
   // customize how each item is shown/hidden during measurement so you can keep custom elements mounted
   renderItemVisibility?: (node: React.ReactNode, meta: RenderItemVisibilityMeta) => React.ReactNode;
+
+  // also re-measure when an item's own size changes without a render (default false)
+  // covers changes React is not involved in: a web font swapping in, an image inside an item loading, a CSS
+  // transition on an item's width, a drag handle. Costs a ResizeObserver over every child, so it is opt-in.
+  // see UseOverflowListOptions.observeItemSizes for the full rationale and the measurements behind it.
+  observeItemSizes?: boolean;
 };
 
 type OverflowListWithItems<T> = BaseOverflowListProps<T> & {
@@ -83,6 +89,9 @@ const OverflowListComponent = React.memo(
       maxRows = 1,
       maxVisibleItems = 100,
       flushImmediately = true,
+      // Deliberately not defaulted here. `useOverflowList` owns the default, and a second copy of it in this
+      // file would just be a place for the two to drift apart.
+      observeItemSizes,
       ...containerProps
     } = props;
 
@@ -97,6 +106,7 @@ const OverflowListComponent = React.memo(
       maxRows,
       maxVisibleItems,
       flushImmediately,
+      observeItemSizes,
     });
     const finalContainerRef = useForkRef(containerRef, forwardedRef);
 

--- a/src/hooks/useChildrenResizeObserver.ts
+++ b/src/hooks/useChildrenResizeObserver.ts
@@ -1,0 +1,154 @@
+import { useRef } from "react";
+
+import { useIsoLayoutEffect } from "./useIsoLayoutEffect";
+
+/**
+ * Runs `callback` once an animation frame has passed with no further call to the returned `bump`.
+ *
+ * Sizes have settled exactly when notifications stop arriving, and "stopped" is the absence of an event, so
+ * something has to tick to notice it. That tick is the frame clock rather than a duration: a size that is still
+ * moving notifies every frame, so one quiet frame separates moving from stopped, and no number has to be picked
+ * out of the air. `bump` is cheap by design — the expensive work is the callback, and it runs once.
+ *
+ * Two chained frames rather than one. Chaining `requestAnimationFrame` to wait past the next rendering update
+ * is an old idiom (Vue's `nextFrame` is `raf(() => raf(fn))`), and here the second frame is what makes the
+ * comparison meaningful: measured in Chrome, callbacks within a frame run in the order `rAF, ResizeObserver`,
+ * so a frame requested from inside a ResizeObserver callback runs *before* the next notification would be
+ * delivered and could not tell quiet from busy.
+ *
+ * That order is deliberately not relied on. The ResizeObserver spec only places its algorithms somewhere within
+ * "update the rendering", and https://github.com/WICG/resize-observer/issues/37 has been open on the relative
+ * order since 2017, so it is not guaranteed and other engines may differ. Comparing a counter across a frame
+ * boundary works under either order — it only ever asks "did anything notify during the frame I just waited
+ * out" — and a test drives both to keep that true.
+ */
+function createFrameSettler(callback: () => void) {
+  let seq = 0;
+  let frame: number | null = null;
+
+  const cancel = () => {
+    if (frame !== null) cancelAnimationFrame(frame);
+    frame = null;
+  };
+
+  /** Waits one frame and either fires or, if something moved in the meantime, waits another. */
+  const waitOneFrame = () => {
+    // Captured before requesting the frame, so it counts every notification delivered up to this point. Any
+    // number of them within a single frame therefore reads as one.
+    const seenAt = seq;
+    frame = requestAnimationFrame(() => {
+      frame = null;
+      if (seq !== seenAt) {
+        // Something moved during the frame just waited out, so it is still moving. One more frame, not a fresh
+        // two: this keeps the wait bounded at two frames from any state once notifications stop.
+        waitOneFrame();
+        return;
+      }
+      callback();
+    });
+  };
+
+  const arm = () => {
+    // The first frame only gets us to a point where a comparison spans a frame boundary under either callback
+    // order; the real test is in the frame after it.
+    frame = requestAnimationFrame(() => {
+      frame = null;
+      waitOneFrame();
+    });
+  };
+
+  return {
+    bump() {
+      seq += 1;
+      // Already waiting: the comparison above will notice this and wait again, so do not stack frames.
+      if (frame === null) arm();
+    },
+    cancel,
+  };
+}
+
+/**
+ * Watches a container's children for size changes and calls `onSettled` once they hold still.
+ *
+ * Exists for size changes React is not involved in: a web font swapping in, an image inside a child finishing
+ * its load, a CSS transition on a child's width, a user dragging a resize handle. Nothing renders, so nothing
+ * that runs on commit can notice them.
+ *
+ * Two details here are not cosmetic, both settled by measurement in Chrome:
+ *
+ * - Children are observed on their **border box**. A child's padding or border changing fires a border-box
+ *   observer and not a content-box one, while `getBoundingClientRect` moves either way. Left on the default
+ *   box, this would stay silent for a real change.
+ *
+ * - `onSettled` waits for **one quiet frame** rather than firing per notification. A child whose size is
+ *   animating or being dragged notifies every frame, and the caller's work is usually far more expensive than
+ *   the notification: measured with 100 children, calling back per notification while dragging a single child
+ *   dropped 29 of 200 frames and took the page from 120fps to 88, where the same drag with the observer off
+ *   dropped none. See `createFrameSettler` for why the wait is a frame count and not a duration.
+ *
+ * The observer is created once and its target set is re-synced on every commit rather than rebuilt, so adding
+ * or removing children costs one `observe`/`unobserve` each rather than a full teardown.
+ *
+ * @param containerRef Container whose direct children are watched.
+ * @param enabled When false, nothing is observed and any pending callback is dropped.
+ * @param onSettled Called after the children's sizes stop changing. Re-read on every render, so it does not
+ * need to be stable.
+ */
+export function useChildrenResizeObserver<T extends HTMLElement>(
+  containerRef: React.RefObject<T | null>,
+  enabled: boolean,
+  onSettled: () => void,
+): void {
+  // Read through a ref so the observer, which outlives any single render, always calls the current closure.
+  const latestOnSettled = useRef(onSettled);
+  latestOnSettled.current = onSettled;
+
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const observedRef = useRef<Set<Element>>(new Set());
+  const settlerRef = useRef<ReturnType<typeof createFrameSettler> | null>(null);
+
+  const stop = () => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+      observedRef.current.clear();
+    }
+    // Cancel a wait already in flight, so turning this off does not still cost one call afterwards.
+    settlerRef.current?.cancel();
+    settlerRef.current = null;
+  };
+
+  // No dependency array: the child list is what has to be tracked, and it is not something a dependency can
+  // describe. Re-syncing is cheap, since only added and removed children are touched.
+  useIsoLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!enabled || !container || typeof ResizeObserver === "undefined") {
+      // Never enabled, or just turned off: drop the observer and any callback it was about to run.
+      stop();
+      return;
+    }
+
+    settlerRef.current ??= createFrameSettler(() => latestOnSettled.current());
+    const settler = settlerRef.current;
+    observerRef.current ??= new ResizeObserver(() => settler.bump());
+
+    const observer = observerRef.current;
+    const observed = observedRef.current;
+    const children = new Set<Element>(Array.from(container.children));
+
+    for (const child of Array.from(observed)) {
+      if (!children.has(child)) {
+        observer.unobserve(child);
+        observed.delete(child);
+      }
+    }
+    for (const child of children) {
+      if (!observed.has(child)) {
+        observer.observe(child, { box: "border-box" });
+        observed.add(child);
+      }
+    }
+  });
+
+  useIsoLayoutEffect(() => stop, []);
+}

--- a/src/hooks/useOverflowList.ts
+++ b/src/hooks/useOverflowList.ts
@@ -10,8 +10,10 @@
 // 3. "normal" phase shows only what fits within constraints. (this is the stable state that we want to keep)
 
 import { useRef, useState } from "react";
+import { flushSync } from "react-dom";
 
 import { getContentSignature, getRowPositionsData, isSameContentSignature } from "../utils";
+import { useChildrenResizeObserver } from "./useChildrenResizeObserver";
 import { useIsoLayoutEffect } from "./useIsoLayoutEffect";
 import { useResizeObserver } from "./useResizeObserver";
 
@@ -30,6 +32,23 @@ export interface UseOverflowListOptions {
    * If false, using requestAnimationFrame to update the state - this avoid forced reflow and improve performance.
    */
   flushImmediately?: boolean;
+  /**
+   * Also re-measure when an item's own size changes without a render (default false).
+   *
+   * Item sizes normally change as part of a render, and the per-commit content check already covers that. The
+   * gap is a size change React is not involved in at all: a web font swapping in, an image inside an item
+   * finishing its load, a CSS transition on an item's width, a user dragging a resize handle. Nothing renders,
+   * so nothing checks, and the visible count stays whatever it was.
+   *
+   * That gap is often hidden. When items grow enough to wrap, the container itself gets taller, its own
+   * ResizeObserver reports that, and a pass runs. It only stays broken when the container's box cannot change:
+   * a fixed-height bar, or any change that shrinks items, since shrinking never wraps.
+   *
+   * Off by default because it means a ResizeObserver over every child. Measured in Chrome at 100 items, the
+   * cost is not detectable, since a pass waits for the sizes to hold still (identical frame times to off), but
+   * it is still work a list that never needs it should not do.
+   */
+  observeItemSizes?: boolean;
 }
 
 export interface UseOverflowListReturn<
@@ -61,6 +80,7 @@ export function useOverflowList<
   maxRows = 1,
   maxVisibleItems = 100,
   flushImmediately = true,
+  observeItemSizes = false,
 }: UseOverflowListOptions): UseOverflowListReturn<TContainer, TOverflow> {
   const [visibleCount, setVisibleCount] = useState(itemCount);
   const [subtractCount, setSubtractCount] = useState(0);
@@ -189,7 +209,7 @@ export function useOverflowList<
   // the same settled DOM, so a pass that changes nothing externally records a matching signature and does
   // not re-enter measuring.
   const settledSignatureRef = useRef<number[] | null>(null);
-  useIsoLayoutEffect(() => {
+  const checkContentSignature = () => {
     if (phase !== "normal") {
       // Mid-pass: whatever we recorded belongs to the previous settled layout.
       settledSignatureRef.current = null;
@@ -214,6 +234,24 @@ export function useOverflowList<
       setPhase("measuring");
       setSubtractCount(0);
     }
+  };
+
+  useIsoLayoutEffect(checkContentSignature);
+
+  // `observeItemSizes` opts into running that same check when an item's box changes with no render at all.
+  // The check decides everything, which is what keeps this from looping: settling hides the overflowed items,
+  // hiding them notifies the observer, but hidden children are excluded from the signature, so the signature
+  // it computes matches the one just recorded and the check does nothing.
+  //
+  // Flushed the same way a container resize is, and for the same reason. The observer runs its callback inside
+  // an animation frame, before that frame paints, so committing synchronously there lands the corrected count
+  // in the frame that is about to be drawn. Left as a scheduled update, the frame can paint the pre-correction
+  // layout first, which is visible as the overflowing item appearing for a beat before it folds into the
+  // indicator. Note this is only about the frame the wait ends on: while sizes are still moving there is
+  // deliberately no pass at all, so the stale layout during a drag is expected and is what keeps it cheap.
+  useChildrenResizeObserver(containerRef, observeItemSizes, () => {
+    if (flushImmediately) flushSync(checkContentSignature);
+    else checkContentSignature();
   });
 
   return {

--- a/src/hooks/useResizeObserver.ts
+++ b/src/hooks/useResizeObserver.ts
@@ -14,6 +14,7 @@ export function useResizeObserver<T extends HTMLElement | null>(
 ): ResizeObserverDimensions | null {
   const resizeObserverRef = useRef<ResizeObserver | null>(null);
   const [dimensions, setDimensions] = useState<ResizeObserverDimensions | null>(null);
+  const lastDimensionsRef = useRef<ResizeObserverDimensions | null>(null);
 
   // Initialize resize observer
   useEffect(() => {
@@ -24,12 +25,30 @@ export function useResizeObserver<T extends HTMLElement | null>(
       if (entries[0]) {
         const entry = entries[0];
         const updateDimensions = () => {
-          setDimensions({
+          const next: ResizeObserverDimensions = {
             width: entry.borderBoxSize[0]?.inlineSize ?? entry.target.clientWidth,
             height: entry.borderBoxSize[0]?.blockSize ?? entry.target.clientHeight,
             contentWidth: entry.contentRect.width,
             contentHeight: entry.contentRect.height,
-          });
+          };
+
+          // Consumers key off the returned object's identity, so storing a fresh object per notification made
+          // every notification look like a change. Notifications reporting the same box do happen: an observer
+          // delivers one when it starts observing, and hiding or revealing an element can produce one without
+          // its box moving. Each of those cost a full re-measure downstream.
+          const last = lastDimensionsRef.current;
+          if (
+            last &&
+            last.width === next.width &&
+            last.height === next.height &&
+            last.contentWidth === next.contentWidth &&
+            last.contentHeight === next.contentHeight
+          ) {
+            return;
+          }
+
+          lastDimensionsRef.current = next;
+          setDimensions(next);
         };
 
         if (flushImmediately) {

--- a/tests/dom/children-resize-observer.test.tsx
+++ b/tests/dom/children-resize-observer.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment jsdom
+// Unit cover for useChildrenResizeObserver on its own, for the parts of it that the list's behaviour cannot
+// discriminate. Uses the same fake layout model, since jsdom has no layout engine — see ./layout-harness.
+
+import { act, cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useChildrenResizeObserver } from "../../src/hooks/useChildrenResizeObserver";
+import { installLayoutHarness } from "./layout-harness";
+
+/**
+ * Advances past the hook's quiet-frame wait. It waits two chained frames, because within a frame the browser
+ * runs rAF callbacks before ResizeObserver ones, so a single frame lands before the next notification would.
+ */
+function advanceToSettled() {
+  vi.advanceTimersToNextFrame();
+  vi.advanceTimersToNextFrame();
+}
+
+let harness: ReturnType<typeof installLayoutHarness> | null = null;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  harness = installLayoutHarness({ containerWidth: 500 });
+});
+
+afterEach(() => {
+  cleanup();
+  harness?.restore();
+  harness = null;
+  vi.useRealTimers();
+});
+
+function Host({ enabled, onSettled }: { enabled: boolean; onSettled: () => void }) {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  useChildrenResizeObserver(containerRef, enabled, onSettled);
+  return (
+    <div ref={containerRef} data-testid="container">
+      <span data-test-width={100}>a</span>
+      <span data-test-width={100}>b</span>
+    </div>
+  );
+}
+
+describe("useChildrenResizeObserver", () => {
+  it("calls the latest callback, not the one it started observing with", () => {
+    // The observer is created once and outlives the render that created it, so a callback captured at that
+    // moment would be frozen along with everything it closes over. In the list that means a stale `phase`,
+    // which is not visible in its behaviour: the pieces the check mutates are refs, shared either way.
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const view = render(<Host enabled onSettled={first} />);
+    // An observer delivers an initial observation for each target it starts on, which arms the wait. Let that
+    // one through first, so what this asserts is the swap and not the mount.
+    act(() => {
+      advanceToSettled();
+    });
+    first.mockClear();
+
+    view.rerender(<Host enabled onSettled={second} />);
+
+    act(() => {
+      harness!.notifyResizeObservers();
+      advanceToSettled();
+    });
+
+    expect(second).toHaveBeenCalled();
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it("observes nothing while disabled, and picks the children up when turned on", () => {
+    const onSettled = vi.fn();
+    const view = render(<Host enabled={false} onSettled={onSettled} />);
+    const container = view.getByTestId("container");
+    const isChild = ({ target }: { target: Element }) => target.parentElement === container;
+
+    expect(harness!.observedBoxes().filter(isChild)).toEqual([]);
+
+    view.rerender(<Host enabled onSettled={onSettled} />);
+
+    expect(harness!.observedBoxes().filter(isChild)).toHaveLength(2);
+  });
+
+  it("drops a pending callback when turned off mid-flight", () => {
+    // Turning it off has to cancel work already queued, not just stop new work. Otherwise a list that opts out
+    // still gets one more pass after the fact.
+    const onSettled = vi.fn();
+    const view = render(<Host enabled onSettled={onSettled} />);
+    act(() => {
+      advanceToSettled();
+    });
+    onSettled.mockClear();
+
+    act(() => {
+      harness!.notifyResizeObservers();
+      // One frame in, so the wait is armed but has not completed.
+      vi.advanceTimersToNextFrame();
+    });
+    expect(onSettled).not.toHaveBeenCalled();
+
+    view.rerender(<Host enabled={false} onSettled={onSettled} />);
+
+    act(() => {
+      advanceToSettled();
+    });
+
+    expect(onSettled).not.toHaveBeenCalled();
+  });
+
+  it("stops observing on unmount", () => {
+    const onSettled = vi.fn();
+    const view = render(<Host enabled onSettled={onSettled} />);
+
+    expect(harness!.observedBoxes().length).toBeGreaterThan(0);
+
+    view.unmount();
+
+    expect(harness!.observedBoxes()).toEqual([]);
+  });
+  it("keeps waiting while the sizes are still moving, then fires once", () => {
+    // The mechanism, stated directly: a notification every frame means still moving, and one quiet frame means
+    // stopped. No duration is involved, so nothing here has a number to tune.
+    const onSettled = vi.fn();
+    render(<Host enabled onSettled={onSettled} />);
+    act(() => {
+      advanceToSettled();
+    });
+    onSettled.mockClear();
+
+    act(() => {
+      for (let frame = 0; frame < 10; frame++) {
+        harness!.notifyResizeObservers();
+        vi.advanceTimersToNextFrame();
+      }
+    });
+
+    expect(onSettled).not.toHaveBeenCalled();
+
+    act(() => {
+      advanceToSettled();
+    });
+
+    expect(onSettled).toHaveBeenCalledTimes(1);
+  });
+
+  // Not covered here, deliberately: whether the wait needs one frame or two. This harness delivers a
+  // notification the moment a test asks for one, where a browser delivers it at a fixed point in the frame, so
+  // a one-frame wait passes everything below. The second frame is justified by measurement instead — in Chrome
+  // a frame's ResizeObserver callbacks run after its rAF callbacks, so a single frame would be compared before
+  // the next notification exists and would fire in the middle of a continuous change. Covering it properly
+  // means teaching the harness to deliver at the frame's observer point, which every other test's timing
+  // currently depends on not doing.
+  //
+  // Whether a browser delivers resize observations before or after that frame's rAF callbacks is not
+  // specified: the ResizeObserver spec only places its algorithms somewhere inside "update the rendering", and
+  // https://github.com/WICG/resize-observer/issues/37 has been open on exactly this since 2017. Chrome runs
+  // rAF first (measured). So drive both orders and require the same outcome, rather than trusting the one
+  // engine that was measured.
+  for (const notifyAfterFrame of [true, false]) {
+    const order = notifyAfterFrame ? "after that frame's callbacks (Chrome)" : "before that frame's callbacks";
+
+    it(`settles when notifications arrive ${order}`, () => {
+      const onSettled = vi.fn();
+      render(<Host enabled onSettled={onSettled} />);
+      act(() => {
+        advanceToSettled();
+      });
+      onSettled.mockClear();
+
+      act(() => {
+        for (let frame = 0; frame < 10; frame++) {
+          if (notifyAfterFrame) {
+            vi.advanceTimersToNextFrame();
+            harness!.notifyResizeObservers();
+          } else {
+            harness!.notifyResizeObservers();
+            vi.advanceTimersToNextFrame();
+          }
+        }
+      });
+
+      // Still moving under either order, so nothing has run yet.
+      expect(onSettled).not.toHaveBeenCalled();
+
+      act(() => {
+        advanceToSettled();
+      });
+
+      expect(onSettled).toHaveBeenCalledTimes(1);
+    });
+  }
+});

--- a/tests/dom/layout-harness.ts
+++ b/tests/dom/layout-harness.ts
@@ -138,12 +138,45 @@ export function installLayoutHarness({ containerWidth }: HarnessOptions) {
     return Object.assign(list, { item: (i: number) => list[i] ?? null }) as unknown as DOMRectList;
   };
 
-  const observers = new Set<{ target: Element; callback: ResizeObserverCallback; observer: ResizeObserver }>();
+  interface Observation {
+    target: Element;
+    callback: ResizeObserverCallback;
+    observer: ResizeObserver;
+    /** Which box was requested. This model does not distinguish them, but the choice still matters: measured
+     * in Chrome, a child's padding or border changing fires a border-box observer and not a content-box one,
+     * while `getBoundingClientRect` moves either way. Recorded so a test can assert what was asked for. */
+    box: ResizeObserverBoxOptions;
+  }
+
+  const observers = new Set<Observation>();
+
+  /** Delivers one observation with its target's current box, the shape a browser reports. */
+  function notifyOne({ target, callback, observer }: Observation) {
+    const rect = target.getBoundingClientRect();
+    callback(
+      [
+        {
+          target,
+          contentRect: rect,
+          borderBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+          contentBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+          devicePixelContentBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
+        } as unknown as ResizeObserverEntry,
+      ],
+      observer,
+    );
+  }
 
   class HarnessResizeObserver implements ResizeObserver {
     constructor(private readonly callback: ResizeObserverCallback) {}
-    observe(target: Element) {
-      observers.add({ target, callback: this.callback, observer: this });
+    observe(target: Element, options?: ResizeObserverOptions) {
+      const entry = { target, callback: this.callback, observer: this, box: options?.box ?? "content-box" };
+      observers.add(entry);
+      // A real ResizeObserver delivers an initial observation for every target it starts observing, so a
+      // consumer has its box before anything resizes. Delivered synchronously here rather than in a
+      // microtask, so that it lands during mount instead of being flushed by whatever a test does first.
+      // Otherwise a test's own first notification stands in for it and looks like a change.
+      notifyOne(entry);
     }
     unobserve(target: Element) {
       for (const entry of observers) if (entry.target === target && entry.observer === this) observers.delete(entry);
@@ -157,21 +190,7 @@ export function installLayoutHarness({ containerWidth }: HarnessOptions) {
 
   /** Fires every observer with its target's current box, as a browser would after a layout change. */
   const notifyResizeObservers = () => {
-    for (const { target, callback, observer } of [...observers]) {
-      const rect = target.getBoundingClientRect();
-      callback(
-        [
-          {
-            target,
-            contentRect: rect,
-            borderBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
-            contentBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
-            devicePixelContentBoxSize: [{ inlineSize: rect.width, blockSize: rect.height }],
-          } as unknown as ResizeObserverEntry,
-        ],
-        observer,
-      );
-    }
+    for (const observation of [...observers]) notifyOne(observation);
   };
 
   return {
@@ -181,6 +200,10 @@ export function installLayoutHarness({ containerWidth }: HarnessOptions) {
       notifyResizeObservers();
     },
     notifyResizeObservers,
+    /** Every target currently observed, and which box it was registered with. */
+    observedBoxes() {
+      return [...observers].map(({ target, box }) => ({ target, box }));
+    },
     restore() {
       Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
       Element.prototype.getClientRects = originalGetClientRects;

--- a/tests/dom/overflow-list.test.tsx
+++ b/tests/dom/overflow-list.test.tsx
@@ -4,12 +4,17 @@
 
 import { act, cleanup, render } from "@testing-library/react";
 import * as React from "react";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { OverflowList } from "../../src";
 import { HARNESS_ROW_HEIGHT, installLayoutHarness } from "./layout-harness";
 
 const ITEM_WIDTH = 100;
 const INDICATOR_WIDTH = 40;
+/** Advances past the item observer's quiet-frame wait, which is two chained frames. */
+function advanceToSettled() {
+  vi.advanceTimersToNextFrame();
+  vi.advanceTimersToNextFrame();
+}
 
 let harness: ReturnType<typeof installLayoutHarness> | null = null;
 
@@ -34,6 +39,8 @@ interface ListOptions {
   keepHiddenItemsMounted?: boolean;
   /** Called on every render of the list, to count measurement passes. */
   onRender?: () => void;
+  /** Opt into re-measuring on item-driven size changes. */
+  observeItemSizes?: boolean;
 }
 
 /** Renders a list in the harness and returns helpers for asserting what ended up visible. */
@@ -46,6 +53,7 @@ function renderList(options: ListOptions) {
     fixedHeight,
     keepHiddenItemsMounted,
     onRender,
+    observeItemSizes,
   } = options;
 
   harness = installLayoutHarness({ containerWidth });
@@ -57,6 +65,7 @@ function renderList(options: ListOptions) {
     <OverflowList
       items={items}
       maxRows={maxRows}
+      observeItemSizes={observeItemSizes}
       data-test-container=""
       {...(fixedHeight !== undefined ? { "data-test-fixed-height": String(fixedHeight) } : {})}
       renderItem={(item) => {
@@ -264,12 +273,25 @@ describe("settling", () => {
     expect(list.rowCount()).toBe(1);
   });
 
-  it("settles to the same result when a resize reports an unchanged box", () => {
-    // `useResizeObserver` stores a fresh object per notification, so an unchanged box still re-runs a pass.
-    // Browsers only fire when the box actually changes, so this is wasted work rather than a bug — what
-    // matters here is that it converges on the same answer instead of drifting.
-    const list = renderList({ containerWidth: 250, itemCount: 5 });
+  it("does not start a pass when a resize reports an unchanged box", () => {
+    // An observer fires once when it starts observing, and hiding or revealing an element can produce a
+    // notification without its box moving. `useResizeObserver` used to store a fresh object per
+    // notification, so each of those cost a full re-measure downstream.
+    const itemCount = 5;
+    let renderItemCalls = 0;
+    // Height pinned, so the container's box is genuinely identical across notifications. Without pinning it
+    // the box really does change while measuring settles, and a notification reporting that is not churn.
+    const list = renderList({
+      containerWidth: 250,
+      itemCount,
+      fixedHeight: HARNESS_ROW_HEIGHT,
+      onRender: () => {
+        renderItemCalls += 1;
+      },
+    });
+
     const before = list.visibleLabels();
+    const afterSettling = renderItemCalls;
 
     act(() => {
       harness!.notifyResizeObservers();
@@ -278,7 +300,159 @@ describe("settling", () => {
       harness!.notifyResizeObservers();
     });
 
+    expect(renderItemCalls).toBe(afterSettling);
     expect(list.visibleLabels()).toEqual(before);
     expect(list.rowCount()).toBe(1);
+  });
+});
+
+describe("observeItemSizes", () => {
+  /** Widens every laid-out child in the DOM, with no re-render, the way a drag handle or a late font would. */
+  function widenLaidOutChildren(container: HTMLElement, width: number) {
+    for (const child of Array.from(container.children)) {
+      if (child.getClientRects().length > 0) child.setAttribute("data-test-width", String(width));
+    }
+  }
+
+  it("is off by default, so the children are not observed", () => {
+    // The default has to stay off: the whole point of the option is that a list which never needs it pays
+    // nothing. Asserted on what gets observed rather than on behaviour, since "nothing happened" is also what
+    // a broken test looks like.
+    const list = renderList({ containerWidth: 250, itemCount: 5 });
+    const container = list.container();
+
+    const observedChildren = harness!.observedBoxes().filter(({ target }) => target.parentElement === container);
+
+    expect(observedChildren).toEqual([]);
+    // The container itself is still observed, which is what drives every other invalidation path.
+    expect(harness!.observedBoxes().some(({ target }) => target === container)).toBe(true);
+  });
+
+  it("leaves an item-driven change unnoticed when off", () => {
+    const list = renderList({
+      containerWidth: 250,
+      itemWidths: [100, 100, 100, 100, 100],
+      fixedHeight: HARNESS_ROW_HEIGHT,
+    });
+
+    expect(list.visibleLabels()).toEqual(["item0", "item1", "+3"]);
+
+    act(() => {
+      widenLaidOutChildren(list.container(), 140);
+      harness!.notifyResizeObservers();
+    });
+
+    // The container's box cannot change and nothing rendered, so the count is stale by design.
+    expect(list.visibleLabels()).toEqual(["item0", "item1", "+3"]);
+  });
+
+  it("observes the children on their border box when on", () => {
+    // Not something this layout model can show by behaviour, and not cosmetic either: measured in Chrome, a
+    // child's padding or border changing fires a border-box observer and not a content-box one, while the
+    // signature reads `getBoundingClientRect`, which moves either way. Left on the default box the observer
+    // would stay silent for exactly the changes the check is looking for, so assert what was asked for.
+    const list = renderList({ containerWidth: 250, itemCount: 5, observeItemSizes: true });
+    const container = list.container();
+
+    const childBoxes = harness!.observedBoxes().filter(({ target }) => target.parentElement === container);
+
+    expect(childBoxes.length).toBeGreaterThan(0);
+    expect(childBoxes.every(({ box }) => box === "border-box")).toBe(true);
+  });
+
+  it("stops observing children that leave the container", () => {
+    // The observed set is re-synced per commit rather than rebuilt, so a missed removal is not visible in the
+    // list's behaviour: it just retains detached nodes and keeps being notified about them.
+    const list = renderList({
+      containerWidth: 250,
+      itemWidths: [100, 100, 100, 100, 100],
+      observeItemSizes: true,
+      fixedHeight: HARNESS_ROW_HEIGHT,
+    });
+
+    expect(harness!.observedBoxes().length).toBeGreaterThan(1);
+
+    list.setItemWidths([100, 100]);
+
+    expect(harness!.observedBoxes().filter(({ target }) => !target.isConnected)).toEqual([]);
+  });
+
+  describe("when on", () => {
+    beforeEach(() => {
+      // The item-driven path waits for sizes to hold still, so these drive the clock rather than sleep.
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("re-measures when an item's box changes with no React involvement", () => {
+      const list = renderList({
+        containerWidth: 250,
+        itemWidths: [100, 100, 100, 100, 100],
+        observeItemSizes: true,
+        fixedHeight: HARNESS_ROW_HEIGHT,
+      });
+
+      expect(list.visibleLabels()).toEqual(["item0", "item1", "+3"]);
+
+      // The observer's initial observation of each child arms the wait, so let that settle before the change
+      // under test, or the change reads as "still moving" and waits another frame.
+      act(() => {
+        advanceToSettled();
+      });
+
+      act(() => {
+        widenLaidOutChildren(list.container(), 140);
+        harness!.notifyResizeObservers();
+        advanceToSettled();
+      });
+
+      expect(list.rowCount()).toBe(1);
+      expect(list.visibleLabels()).toEqual(["item0", "+4"]);
+    });
+
+    it("waits for the sizes to hold still before measuring", () => {
+      // A dragged handle or an animating width notifies on every frame. Re-measuring per frame is what the
+      // quiet-frame wait exists to avoid, so notifications that keep arriving must keep the pass waiting.
+      const itemCount = 5;
+      let renderItemCalls = 0;
+      const list = renderList({
+        containerWidth: 250,
+        itemWidths: Array.from({ length: itemCount }, () => 100),
+        observeItemSizes: true,
+        fixedHeight: HARNESS_ROW_HEIGHT,
+        onRender: () => {
+          renderItemCalls += 1;
+        },
+      });
+
+      act(() => {
+        advanceToSettled();
+      });
+      const settled = renderItemCalls;
+      const before = list.visibleLabels();
+
+      // Ten frames of a still-moving size: each notification arrives before the previous could settle.
+      act(() => {
+        for (let frame = 1; frame <= 10; frame++) {
+          widenLaidOutChildren(list.container(), 100 + frame * 4);
+          harness!.notifyResizeObservers();
+          vi.advanceTimersToNextFrame();
+        }
+      });
+
+      expect(renderItemCalls).toBe(settled);
+      expect(list.visibleLabels()).toEqual(before);
+
+      // Now the sizes hold still, and exactly one pass runs against the final sizes.
+      act(() => {
+        advanceToSettled();
+      });
+
+      expect(list.rowCount()).toBe(1);
+      expect(list.visibleLabels()).toEqual(["item0", "+4"]);
+    });
   });
 });


### PR DESCRIPTION
Two changes to what re-triggers measurement. Bumps to `0.5.0` (new public prop).

## fix: `useResizeObserver` re-measured on an unchanged box

Consumers key off the returned object's identity, so storing a fresh object per notification made every notification look like a resize. Notifications reporting the same box do happen: an observer delivers one when it starts observing, and hiding or revealing an element can produce one without its box moving. Each cost a full re-measure downstream.

## feat: `observeItemSizes`, off by default

Measurement re-runs on **every render** (item sizes compared against the sizes the current count was chosen for) and on **container resize**. Both need a trigger, so a size change React is not involved in is missed: a web font swapping in, an image loading, a CSS transition, a drag handle.

It usually hides. Items that grow enough to wrap make the container taller, and its own observer notices, so the list looks like it is tracking the items when it is really tracking itself. It stays missed when the container's box cannot change (a fixed-height bar), or when items **shrink**, since shrinking never wraps.

`observeItemSizes` closes that with a `ResizeObserver` over the children, extracted as `useChildrenResizeObserver` (internal, not exported). Off by default: most lists never need it.

### Two load-bearing details, both settled by measurement in Chrome

**Border box, not content box.** A child's padding or border changing fires a border-box observer and not a content-box one, while `getBoundingClientRect` moves either way:

| child change | content-box fires | border-box fires | signature moves |
| --- | --- | --- | --- |
| padding | no | yes | yes |
| border | no | yes | yes |
| text | yes | yes | yes |

Left on the default box, the observer would stay silent for exactly the changes the check looks for.

**A pass waits for one quiet animation frame** rather than running per notification. Dragging a single child, 100 items, 3s:

| | fps | dropped frames | passes during drag | correction after release |
| --- | --- | --- | --- | --- |
| option off | 120 | 0/200 | 0 | never (stale) |
| per notification | 88 | 29/200 | ~199 | live |
| quiet frame | 121 | 0/200 | 0 | ~2 frames |

The wait is a frame count, not a duration, so there is no interval to tune: a size still moving notifies every frame, so one quiet frame separates moving from stopped. Two chained frames because in Chrome a frame's `ResizeObserver` callbacks run after its `rAF` callbacks. That order is **not** specified ([WICG/resize-observer#37](https://github.com/WICG/resize-observer/issues/37) has been open on it since 2017), so the comparison is written to hold under either order, and tests drive both.

Consequence worth knowing: the list is deliberately stale *while* sizes are moving and corrects when they stop. That is what keeps it free.

The item path is flushed like the container path when `flushImmediately` is set, so the corrected count lands in the frame about to be painted rather than a beat later.

## Storybook

`Behaviour/ResizableChildren` puts a native `resize` handle on every item **and** on the container, with a live `observeItemSizes` toggle and a per-frame readout. Dragging the container exercises the path that needs no opt-in; dragging an item exercises the one that does. Same gesture, and only one is covered by default.

Also imports the Tailwind stylesheet in `.storybook/preview.ts`. It was never imported, so every class in every story was inert. This changes how the other stories look.

## Testing

45 tests. Mutation tested by reverting each decision one at a time; ten of eleven are caught by a failing test:

| reverted | caught by |
| --- | --- |
| identity-churn guard | 3 tests |
| default flipped to on | `is off by default` |
| hook never wired up | 4 tests |
| per-commit check | 3 tests |
| `enabled` ignored in the hook | 3 tests |
| border-box to content-box | `observes them on their border box` |
| quiet-frame wait | 5 tests |
| counter captured after requesting the frame | 4 tests |
| pending wait not cancelled on stop | `drops a pending callback` |
| unobserve stale children | `stops observing children that leave` |
| **two frames to one frame** | **nothing** |

Two known gaps, both recorded in comments rather than papered over:

- **one frame vs two** is not covered. The jsdom harness delivers a notification the moment a test asks, where a browser delivers it at a fixed point in the frame, so a one-frame wait passes every test. Covering it means teaching the harness to deliver at the frame's observer point, which every other test's timing depends on not doing. The second frame rests on the Chrome measurement.
- the **`flushSync`** on the item path is not covered either: everything in the suite runs inside `act()`, which flushes batching regardless. It rests on consistency with the container path and on what `flushImmediately` documents.

Two tests assert the *off* path, so "off means off" is pinned rather than assumed: children are not observed at all, and an item-driven change stays unnoticed.

No regression in the browser: #21 holds one row through every badge stage, #23's four lists are unchanged through popover open and close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `observeItemSizes` support to detect changes in child dimensions and update overflow layouts after sizes stabilize.
  * Added interactive Storybook examples for resizing list items and containers.

* **Bug Fixes**
  * Prevented unnecessary updates when container dimensions remain unchanged.
  * Improved handling of rapidly changing and detached items.

* **Documentation**
  * Documented measurement triggers, child-size observation, and update batching behavior.

* **Chores**
  * Updated the package version to 0.5.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->