### PR TITLE
fix(ci): stop forwarding --if-present to the test script on publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - run: pnpm -s test --if-present
+      # `--if-present` must precede the script name or pnpm forwards it to the script instead of consuming
+      # it. It sat here harmlessly while there was no `test` script, since pnpm skipped the missing script and
+      # forwarded nothing. Once one existed the flag reached vitest, which rejects it, and publishing failed
+      # for two releases. The guard has no purpose now that the script is permanent.
+      - run: pnpm -s test
       - run: pnpm -s build
       - name: Build demo
         run: pnpm -s demo:build


### PR DESCRIPTION
`release-and-publish` has failed on every merge since #25, so **nothing has published since #24**. npm is on `0.4.3`; `main` is on `0.5.0`.

## Cause

`.github/workflows/publish.yml`:

```yaml
- run: pnpm -s test --if-present
```

pnpm consumes `--if-present` only when it **precedes** the script name. Trailing it, the flag is forwarded to the script, so the step ran `vitest run --if-present`:

```
CACError: Unknown option `--ifPresent`
```

It sat there harmlessly for a long time because there was no `test` script: pnpm skipped the missing script and forwarded nothing. Commit 0b1774f (#25) added `"test": "vitest run"`, so the flag started reaching vitest.

| PR | publish |
| --- | --- |
| #20, #22, #23, #24 | success |
| **#25** (added the `test` script) | **failure** |
| #27 | **failure** |

`ci.yml` was never affected, since it calls `pnpm test`.

## Fix

Dropped the flag rather than reordering it. The guard has no purpose now that the script is permanent, and it is precisely what hid the failure for two releases. Verified `pnpm -s test` runs the suite (45 passed) and that no other workflow has the same ordering.

## Releasing 0.5.0

Merging this does **not** publish. The workflow triggers on pushes to `main` that touch `package.json`, and this change does not touch it. Re-running the failed run would not help either, since a re-run uses the workflow file at that commit, which still has the bug.

So `0.5.0` needs a `workflow_dispatch` run after this merges. The job already skips when the version is on npm, so it is safe to dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
